### PR TITLE
#11 bug fix : gap between content and nav / fixing navbar/logout on mobile.

### DIFF
--- a/src/context/ContextBuilder.js
+++ b/src/context/ContextBuilder.js
@@ -94,13 +94,13 @@ function ContextBuilder({ sanitySchemas }) {
           <Tab label={I18n.get("fullStackDev")} style={{ fontSize: 18 }} />
         </Tabs>
       </AppBar>
-      <TabPanel value={value} index={0} style={{ margin: -30 }}>
+      <TabPanel value={value} index={0} className = "tabPanelCont">
         {renderTopicsList(sanitySchemas.hubSchemas)}
       </TabPanel>
-      <TabPanel value={value} index={1} style={{ margin: -30 }}>
+      <TabPanel value={value} index={1} className = "tabPanelCont">
         {renderTopicsList(sanitySchemas.economicSchemas)}
       </TabPanel>
-      <TabPanel value={value} index={2} style={{ margin: -30 }}>
+      <TabPanel value={value} index={2} className = "tabPanelCont">
         {renderTopicsList(sanitySchemas.technicalSchemas)}
       </TabPanel>
 

--- a/src/index.css
+++ b/src/index.css
@@ -59,6 +59,7 @@ input[type="file"] {
   .root-padding {
     padding-left: 24px;
     padding-right: 16px;
+    margin-bottom: 12vh;
   }
   .sticky-nav {
     position: fixed;

--- a/src/index.css
+++ b/src/index.css
@@ -17,11 +17,44 @@ body {
   right: 15px;
   cursor: pointer;
   font-size: 36px;
+  z-index: 10;
 }
+
+/* Typography */
+
+h1 {
+  color: rgb(36, 35, 35);
+  margin-top: 36px;
+  font-weight: 400;
+  font-size: 36px;
+}
+select.form-control,
+textarea.form-control,
+input.form-control {
+  font-size: 16px;
+}
+input[type="file"] {
+  width: 100%;
+}
+
+/* mobile/tablet styling */
 
 @media screen and (max-width: 768px) {
   html {
     padding-top: -74px;
+  }
+   h1 {
+      color: rgb(36, 35, 35);
+      margin-top: 36px;
+      font-weight: 400;
+      font-size: 9vw;
+    }
+    header span{
+      font-size: 3vw;
+    }
+  .tabPanelCont{
+    margin: -8.5vw;
+    margin-bottom: 6vh;
   }
   .root-padding {
     padding-left: 24px;
@@ -34,7 +67,9 @@ body {
     width: 100%;
     padding-left: -24px;
   }
-
+  .sticky-nav button {
+    min-width: 0;
+  }
   .sidenav {
     height: 100%;
     position: fixed;
@@ -47,11 +82,10 @@ body {
     -webkit-transition: all 0.5s ease 0s;
     visibility: hidden;
   }
-
   .sticky-chat {
     visibility: hidden;
   }
- 
+
   .notes-overflow {
     overflow: scroll;
     max-height: 180px;
@@ -71,7 +105,6 @@ body {
   .sticky-nav {
     visibility: hidden;
   }
-
   .sidenav {
     display: flex;
     flex-direction: column;
@@ -121,23 +154,6 @@ body {
 .blue-black {
   background-color: rgb(0, 170, 212);
   color: rgb(52, 58, 64);
-}
-
-/* Typography */
-
-h1 {
-  color: rgb(36, 35, 35);
-  margin-top: 36px;
-  font-weight: 400;
-  font-size: 36px;
-}
-select.form-control,
-textarea.form-control,
-input.form-control {
-  font-size: 16px;
-}
-input[type="file"] {
-  width: 100%;
 }
 
 /* Overflow classes */


### PR DESCRIPTION
# #11  Mobile Nav Padding Top bug fix

### These changes will add a gap between the bottom of pages and the bottom nav bar as to not cut off content, as well as fixing the bottom nav bar breaking on mobile/tablet. It also changes some font sizing and issues with logout z-index.

- [x] Fixing far right nav bar icon not appearing on certain screens
- [x] Adding gap to bottom of screens between content and nav bar.
- [x] Z-index fix for logout button
- [x] Font sizing fixes


### Fixing nav bar icon 

Context: The nav bar would break around 600px width and on really small viewports. This was due to a css rule from material ui creating a min-width on the buttons in the nav. I gave the navbar buttons all a rule overruling the MUI rule and this fixed the issue. 

Before:
![bottomnav-1](https://user-images.githubusercontent.com/75534476/131836641-c4ff9e6b-51db-4d72-88af-8766c3ccb0a2.gif)
After:
![bottomnav-2](https://user-images.githubusercontent.com/75534476/131836665-69d1fff5-c98b-449e-b02d-7be053915435.gif)

### Creating a gap between content and nav

Context: On mobile/tablets going to the bottom of the screen, the navbar would overlap content. I was able to fix this issue on the library of context, I just added a class to the tab container which holds all the media cards. I then added a margin-bottom rule to this class and made it responsive by using vh units thus there's no obscenely large gap on any viewports. I made a similar fix with the mentorship page, the container already had a class defined however so it was just adding a margin-bottom rule to it.

Before:
![gap-1](https://user-images.githubusercontent.com/75534476/131836913-a7b78558-23ac-451b-aa29-8cdf51f29c4c.PNG)
![gap2-1](https://user-images.githubusercontent.com/75534476/131981626-338fdfe1-3962-44b5-9c8f-eb8014ffd8e5.PNG)
After:
![gap-2](https://user-images.githubusercontent.com/75534476/131836934-74b4d91f-1ff8-4976-a7d9-0d15c4d4803c.PNG)
![gap2-2](https://user-images.githubusercontent.com/75534476/131981646-a480b75f-076d-45b1-8f2b-45419f820eab.PNG)

### Z-index fix for logout
Before:
![logout-1](https://user-images.githubusercontent.com/75534476/131836998-8e40242d-daf5-41ce-8147-ce0e090f7e45.PNG)
After:
![logout-2](https://user-images.githubusercontent.com/75534476/131837011-86210b2f-19d9-4a41-beea-f8b86415af5f.PNG)

### Font size fixes:

Context: The library of context tab picker had a very large font size that on some screens would not allow you to click the last tab. I changed the font to be responsive on mobile/tablet and this fixed the issue for the most part.

Before:
![fontsize-1](https://user-images.githubusercontent.com/75534476/131837064-7219357d-a9aa-4ff7-8bf7-dcb1c3a726c6.PNG)
After:
![fontsize-2](https://user-images.githubusercontent.com/75534476/131837119-9a439bc0-035d-4f1a-9a5f-7eeab7cd3c97.PNG)



