### PR TITLE
♻️  refactor(NewSubmitProofModal): converted class component to hooks

### DIFF
--- a/src/components/ArenaProofModal.js
+++ b/src/components/ArenaProofModal.js
@@ -8,6 +8,7 @@ import LoaderButton from "./LoaderButton";
 import { errorToast, successToast } from "../libs/toasts";
 import { I18n } from "@aws-amplify/core";
 import Storage from "@aws-amplify/storage";
+import { uploadToS3 } from "../libs/s3";
 
 /**
  * The Arena Proof Modal is where a player submits the proof of their achievement, and where they/their coach (I believe - review) can review the proof.
@@ -20,123 +21,130 @@ import Storage from "@aws-amplify/storage";
  */
 
 export default class ArenaProofModal extends Component {
-  constructor(props) {
-    super(props);
+	constructor(props) {
+		super(props);
 
-    this.state = {
-      athleteNotes: "",
-      github: "https://github.com/",
-      isChanging: false,
-      isLoading: false,
-      experienceId: "",
-      key: "",
-      trashTalk: "",
-    };
-  }
+		this.state = {
+			athleteNotes: "",
+			github: "https://github.com/",
+			isChanging: false,
+			isLoading: false,
+			experienceId: "",
+			key: "",
+			trashTalk: "",
+		};
+	}
 
-  validateForm() {
-    return this.state.athleteNotes.length > 0 && this.state.github.length > 0;
-  }
+	validateForm() {
+		return this.state.athleteNotes.length > 0 && this.state.github.length > 0;
+	}
 
-  handleChange = (event) => {
-    this.setState({
-      [event.target.id]: event.target.value,
-    });
-  };
+	handleChange = (event) => {
+		this.setState({
+			[event.target.id]: event.target.value,
+		});
+	};
 
-  onChange = async (e) => {
-    this.props.setLoading(true);
-    let fileType = e.target.files[0].name.split(".");
-    const file = e.target.files[0];
-    // the name to save is the sprint_id_teamIndex_dayIndex_missionIndex
-    try {
-      let pictureKey = await Storage.put(
-        `${this.props.sprint.id}_0_${this.props.day}_${this.props.activeIndex}.${fileType[1]}`,
-        file,
-        {
-          bucket: process.env.REACT_APP_PROOF_BUCKET,
-        }
-      );
-      this.setState({ key: pictureKey.key });
-      successToast("Proof successfully uploaded.");
-      this.props.setLoading(false);
-    } catch (e) {
-      errorToast(e);
-      this.props.setLoading(false);
-    }
-  };
+	onChange = async (e) => {
+		this.props.setLoading(true);
+		let fileType = e.target.files[0].name.split(".");
+		const file = e.target.files[0];
+		// the name to save is the sprint_id_teamIndex_dayIndex_missionIndex
+		try {
+			// let pictureKey = await Storage.put(
+			//   `${this.props.sprint.id}_0_${this.props.day}_${this.props.activeIndex}.${fileType[1]}`,
+			//   file,
+			//   {
+			//     bucket: process.env.REACT_APP_PROOF_BUCKET,
+			//   }
+			// );
 
-  render() {
-    return (
-      <div>
-        <Modal show={this.props.show} onHide={this.props.handleClose}>
-          <Modal.Header closeButton>
-            <Modal.Title>{I18n.get("submitProof")}</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-            {this.props.view === "submit" ? (
-              <React.Fragment>
-                <FormGroup bsSize="large" controlId="trashTalk">
-                  <ControlLabel>{I18n.get("trashTalkPSA")}</ControlLabel>
-                  <FormControl
-                    type="text"
-                    onChange={this.handleChange}
-                    value={this.state.trashTalk}
-                  />
-                </FormGroup>
-                <h3>{I18n.get("attachment")}</h3>
-                <input type="file" onChange={(evt) => this.onChange(evt)} />
-                <br />
-                <div className="flex">
-                  <Button onClick={this.props.handleClose}>
-                    {I18n.get("close")}
-                  </Button>
-                  <LoaderButton
-                    onClick={() => {
-                      this.props.handleChange(
-                        this.props.activeMission,
-                        this.props.activeIndex,
-                        this.props.day,
-                        this.state.key,
-                        this.props.activeSprintId,
-                        `${this.props.user.fName} just completed ${
-                          this.props.activeMission.title
-                        }.${
-                          this.state.trashTalk.length > 0
-                            ? `They also said: "${this.state.trashTalk}"`
-                            : ""
-                        } `
-                      );
-                      this.setState({ key: "", trashTalk: "" });
-                      this.props.handleClose();
-                    }}
-                    bsSize="large"
-                    text={I18n.get("submitProof")}
-                    loadingText={I18n.get("creating")}
-                    // disabled={!this.validateForm()}
-                    isLoading={this.props.loading}
-                  />
-                </div>
-              </React.Fragment>
-            ) : (
-              <div>
-                {this.props.activeMission.proofLink !== "" ? (
-                  <a
-                    href={`https://${process.env.REACT_APP_PROOF_BUCKET}-prod.s3.amazonaws.com/public/${this.props.activeMission.proofLink}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {I18n.get("viewProof")}
-                  </a>
-                ) : (
-                  <p>{I18n.get("noProof")}</p>
-                )}
-              </div>
-            )}
-          </Modal.Body>
-          <Modal.Footer />
-        </Modal>
-      </div>
-    );
-  }
+			const pictureKey = uploadToS3(
+				`${this.props.sprint.id}_0_${this.props.day}_${this.props.activeIndex}`,
+				file,
+				fileType[1]
+			);
+
+			this.setState({ key: pictureKey.key });
+			successToast("Proof successfully uploaded.");
+			this.props.setLoading(false);
+		} catch (e) {
+			errorToast(e);
+			this.props.setLoading(false);
+		}
+	};
+
+	render() {
+		return (
+			<div>
+				<Modal show={this.props.show} onHide={this.props.handleClose}>
+					<Modal.Header closeButton>
+						<Modal.Title>{I18n.get("submitProof")}</Modal.Title>
+					</Modal.Header>
+					<Modal.Body>
+						{this.props.view === "submit" ? (
+							<React.Fragment>
+								<FormGroup bsSize="large" controlId="trashTalk">
+									<ControlLabel>{I18n.get("trashTalkPSA")}</ControlLabel>
+									<FormControl
+										type="text"
+										onChange={this.handleChange}
+										value={this.state.trashTalk}
+									/>
+								</FormGroup>
+								<h3>{I18n.get("attachment")}</h3>
+								<input type="file" onChange={(evt) => this.onChange(evt)} />
+								<br />
+								<div className="flex">
+									<Button onClick={this.props.handleClose}>
+										{I18n.get("close")}
+									</Button>
+									<LoaderButton
+										onClick={() => {
+											this.props.handleChange(
+												this.props.activeMission,
+												this.props.activeIndex,
+												this.props.day,
+												this.state.key,
+												this.props.activeSprintId,
+												`${this.props.user.fName} just completed ${
+													this.props.activeMission.title
+												}.${
+													this.state.trashTalk.length > 0
+														? `They also said: "${this.state.trashTalk}"`
+														: ""
+												} `
+											);
+											this.setState({ key: "", trashTalk: "" });
+											this.props.handleClose();
+										}}
+										bsSize="large"
+										text={I18n.get("submitProof")}
+										loadingText={I18n.get("creating")}
+										// disabled={!this.validateForm()}
+										isLoading={this.props.loading}
+									/>
+								</div>
+							</React.Fragment>
+						) : (
+							<div>
+								{this.props.activeMission.proofLink !== "" ? (
+									<a
+										href={`https://${process.env.REACT_APP_PROOF_BUCKET}-prod.s3.amazonaws.com/public/${this.props.activeMission.proofLink}`}
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										{I18n.get("viewProof")}
+									</a>
+								) : (
+									<p>{I18n.get("noProof")}</p>
+								)}
+							</div>
+						)}
+					</Modal.Body>
+					<Modal.Footer />
+				</Modal>
+			</div>
+		);
+	}
 }

--- a/src/learn/NewSubmitProofModal.js
+++ b/src/learn/NewSubmitProofModal.js
@@ -7,7 +7,6 @@ import Button from "react-bootstrap/lib/Button";
 import LoaderButton from "../components/LoaderButton";
 import { errorToast, successToast } from "../libs/toasts";
 import { I18n } from "@aws-amplify/core";
-import Storage from "@aws-amplify/storage";
 
 /**
  * This is the modal where a player submits the proof for their Arena event
@@ -44,15 +43,11 @@ export default function SubmitProof({
 
 		// the name to save is the id of the experience_01 or whatever the number is.
 		try {
-			let pictureKey = await Storage.put(
-				`${mongoExperience.id}${activeExperience.priority}.${fileType[1]}`,
+			await uploadToS3(
+				`${mongoExperience.id}${activeExperience.priority}`,
 				file,
-				{
-					bucket: process.env.REACT_APP_PROOF_BUCKET,
-				}
+				fileType[1]
 			);
-
-			console.log("Key: ", pictureKey);
 
 			successToast("Proof successfully uploaded.");
 		} catch (err) {

--- a/src/learn/NewSubmitProofModal.js
+++ b/src/learn/NewSubmitProofModal.js
@@ -32,6 +32,7 @@ export default function SubmitProof({
 
 	const handleChange = (event) => {
 		setFormData({
+			...formData,
 			[event.target.id]: event.target.value,
 		});
 	};

--- a/src/learn/NewSubmitProofModal.js
+++ b/src/learn/NewSubmitProofModal.js
@@ -1,13 +1,13 @@
-import React, { useState } from 'react';
-import FormGroup from 'react-bootstrap/lib/FormGroup';
-import ControlLabel from 'react-bootstrap/lib/ControlLabel';
-import FormControl from 'react-bootstrap/lib/FormControl';
-import Modal from 'react-bootstrap/lib/Modal';
-import Button from 'react-bootstrap/lib/Button';
-import LoaderButton from '../components/LoaderButton';
-import { errorToast, successToast } from '../libs/toasts';
-import { I18n } from '@aws-amplify/core';
-import Storage from '@aws-amplify/storage';
+import React, { useState } from "react";
+import FormGroup from "react-bootstrap/lib/FormGroup";
+import ControlLabel from "react-bootstrap/lib/ControlLabel";
+import FormControl from "react-bootstrap/lib/FormControl";
+import Modal from "react-bootstrap/lib/Modal";
+import Button from "react-bootstrap/lib/Button";
+import LoaderButton from "../components/LoaderButton";
+import { errorToast, successToast } from "../libs/toasts";
+import { I18n } from "@aws-amplify/core";
+import Storage from "@aws-amplify/storage";
 
 /**
  * This is the modal where a player submits the proof for their Arena event
@@ -17,8 +17,8 @@ import Storage from '@aws-amplify/storage';
 export default function SubmitProof({ show, handleClose, markSubmitted, activeExperience, mongoExperience }) {
 	const [isChanging, setChanging] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
-	const [experienceId, setExperienceId] = useState('');
-	const [formData, setFormData] = useState({ github: '', athleteNotes: '' });
+	const [experienceId, setExperienceId] = useState("");
+	const [formData, setFormData] = useState({ github: "", athleteNotes: "" });
 
 	const validateForm = () => {
 		return formData.athleteNotes.length > 0 && formData.github.length > 0;
@@ -33,7 +33,7 @@ export default function SubmitProof({ show, handleClose, markSubmitted, activeEx
 	// @TODO: Is this function repetitive? With Arena proof modal?
 	const onChange = async (e) => {
 		const file = e.target.files[0];
-		let fileType = e.target.files[0].name.split('.');
+		let fileType = e.target.files[0].name.split(".");
 
 		// the name to save is the id of the experience_01 or whatever the number is.
 		try {
@@ -41,9 +41,9 @@ export default function SubmitProof({ show, handleClose, markSubmitted, activeEx
 				bucket: process.env.REACT_APP_PROOF_BUCKET,
 			});
 
-			console.log('Key: ', pictureKey);
+			console.log("Key: ", pictureKey);
 
-			successToast('Proof successfully uploaded.');
+			successToast("Proof successfully uploaded.");
 		} catch (err) {
 			errorToast(err);
 		}
@@ -53,47 +53,39 @@ export default function SubmitProof({ show, handleClose, markSubmitted, activeEx
 		<div>
 			<Modal show={show} onHide={handleClose}>
 				<Modal.Header closeButton>
-					<Modal.Title>{I18n.get('submitProof')}</Modal.Title>
+					<Modal.Title>{I18n.get("submitProof")}</Modal.Title>
 				</Modal.Header>
-
 				<Modal.Body>
-					<FormGroup bsSize='large' controlId='athleteNotes'>
-						<ControlLabel>{I18n.get('notesForCoach')}</ControlLabel>
-						<FormControl type='text' onChange={handleChange} value={formData.athleteNotes} />
+					<FormGroup bsSize="large" controlId="athleteNotes">
+						<ControlLabel>{I18n.get("notesForCoach")}</ControlLabel>
+						<FormControl type="text" onChange={handleChange} value={formData.athleteNotes} />
 					</FormGroup>
-
-					<FormGroup bsSize='large' controlId='github'>
-						<ControlLabel>{I18n.get('submitLink')}</ControlLabel>
-						<FormControl type='text' onChange={handleChange} value={formData.github} />
+					<FormGroup bsSize="large" controlId="github">
+						<ControlLabel>{I18n.get("submitLink")}</ControlLabel>
+						<FormControl type="text" onChange={handleChange} value={formData.github} />
 					</FormGroup>
-
-					<h3>{I18n.get('attachment')}</h3>
-
-					<input type='file' accept='image/png' onChange={(evt) => onChange(evt)} />
-
+					<h3>{I18n.get("attachment")}</h3>
+					<input type="file" accept="image/png" onChange={(evt) => onChange(evt)} />
 					<br />
-
-					<div className='flex'>
-						<Button onClick={handleClose}>{I18n.get('close')}</Button>
-
+					<div className="flex">
+						<Button onClick={handleClose}>{I18n.get("close")}</Button>
 						<LoaderButton
 							block
 							onClick={() => {
 								markSubmitted(activeExperience, formData.github, formData.athleteNotes);
 								setFormData({
-									athleteNotes: '',
-									github: '',
+									athleteNotes: "",
+									github: "",
 								});
 							}}
-							bsSize='large'
-							text={I18n.get('submitProof')}
-							loadingText={I18n.get('saving')}
+							bsSize="large"
+							text={I18n.get("submitProof")}
+							loadingText={I18n.get("saving")}
 							disabled={validateForm()}
 							isLoading={isChanging}
 						/>
 					</div>
 				</Modal.Body>
-
 				<Modal.Footer />
 			</Modal>
 		</div>

--- a/src/learn/NewSubmitProofModal.js
+++ b/src/learn/NewSubmitProofModal.js
@@ -14,7 +14,13 @@ import Storage from "@aws-amplify/storage";
  * @TODO Issue #26
  */
 
-export default function SubmitProof({ show, handleClose, markSubmitted, activeExperience, mongoExperience }) {
+export default function SubmitProof({
+	show,
+	handleClose,
+	markSubmitted,
+	activeExperience,
+	mongoExperience,
+}) {
 	const [isChanging, setChanging] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
 	const [experienceId, setExperienceId] = useState("");
@@ -37,9 +43,13 @@ export default function SubmitProof({ show, handleClose, markSubmitted, activeEx
 
 		// the name to save is the id of the experience_01 or whatever the number is.
 		try {
-			let pictureKey = await Storage.put(`${mongoExperience.id}${activeExperience.priority}.${fileType[1]}`, file, {
-				bucket: process.env.REACT_APP_PROOF_BUCKET,
-			});
+			let pictureKey = await Storage.put(
+				`${mongoExperience.id}${activeExperience.priority}.${fileType[1]}`,
+				file,
+				{
+					bucket: process.env.REACT_APP_PROOF_BUCKET,
+				}
+			);
 
 			console.log("Key: ", pictureKey);
 
@@ -58,7 +68,11 @@ export default function SubmitProof({ show, handleClose, markSubmitted, activeEx
 				<Modal.Body>
 					<FormGroup bsSize="large" controlId="athleteNotes">
 						<ControlLabel>{I18n.get("notesForCoach")}</ControlLabel>
-						<FormControl type="text" onChange={handleChange} value={formData.athleteNotes} />
+						<FormControl
+							type="text"
+							onChange={handleChange}
+							value={formData.athleteNotes}
+						/>
 					</FormGroup>
 					<FormGroup bsSize="large" controlId="github">
 						<ControlLabel>{I18n.get("submitLink")}</ControlLabel>
@@ -72,7 +86,11 @@ export default function SubmitProof({ show, handleClose, markSubmitted, activeEx
 						<LoaderButton
 							block
 							onClick={() => {
-								markSubmitted(activeExperience, formData.github, formData.athleteNotes);
+								markSubmitted(
+									activeExperience,
+									formData.github,
+									formData.athleteNotes
+								);
 								setFormData({
 									athleteNotes: "",
 									github: "",

--- a/src/learn/NewSubmitProofModal.js
+++ b/src/learn/NewSubmitProofModal.js
@@ -1,124 +1,101 @@
-import React, { Component } from "react";
-import FormGroup from "react-bootstrap/lib/FormGroup";
-import ControlLabel from "react-bootstrap/lib/ControlLabel";
-import FormControl from "react-bootstrap/lib/FormControl";
-import Modal from "react-bootstrap/lib/Modal";
-import Button from "react-bootstrap/lib/Button";
-import LoaderButton from "../components/LoaderButton";
-import { errorToast, successToast } from "../libs/toasts";
-import { I18n } from "@aws-amplify/core";
-import Storage from "@aws-amplify/storage";
+import React, { useState } from 'react';
+import FormGroup from 'react-bootstrap/lib/FormGroup';
+import ControlLabel from 'react-bootstrap/lib/ControlLabel';
+import FormControl from 'react-bootstrap/lib/FormControl';
+import Modal from 'react-bootstrap/lib/Modal';
+import Button from 'react-bootstrap/lib/Button';
+import LoaderButton from '../components/LoaderButton';
+import { errorToast, successToast } from '../libs/toasts';
+import { I18n } from '@aws-amplify/core';
+import Storage from '@aws-amplify/storage';
 
 /**
  * This is the modal where a player submits the proof for their Arena event
  * @TODO Issue #26
- * @TODO Issue #52
  */
 
-export default class SubmitProof extends Component {
-  constructor(props) {
-    super(props);
+export default function SubmitProof({ show, handleClose, markSubmitted, activeExperience, mongoExperience }) {
+	const [isChanging, setChanging] = useState(false);
+	const [isLoading, setIsLoading] = useState(false);
+	const [experienceId, setExperienceId] = useState('');
+	const [formData, setFormData] = useState({ github: '', athleteNotes: '' });
 
-    this.state = {
-      athleteNotes: "",
-      github: "https://github.com/",
-      isChanging: false,
-      isLoading: false,
-      experienceId: "",
-    };
-  }
+	const validateForm = () => {
+		return formData.athleteNotes.length > 0 && formData.github.length > 0;
+	};
 
-  validateForm() {
-    return this.state.athleteNotes.length > 0 && this.state.github.length > 0;
-  }
+	const handleChange = (event) => {
+		setFormData({
+			[event.target.id]: event.target.value,
+		});
+	};
 
-  handleChange = (event) => {
-    this.setState({
-      [event.target.id]: event.target.value,
-    });
-  };
+	// @TODO: Is this function repetitive? With Arena proof modal?
+	const onChange = async (e) => {
+		const file = e.target.files[0];
+		let fileType = e.target.files[0].name.split('.');
 
-  // @TODO: Is this function repetitive? With Arena proof modal?
-  onChange = async (e) => {
-    const file = e.target.files[0];
-    let fileType = e.target.files[0].name.split(".");
+		// the name to save is the id of the experience_01 or whatever the number is.
+		try {
+			let pictureKey = await Storage.put(`${mongoExperience.id}${activeExperience.priority}.${fileType[1]}`, file, {
+				bucket: process.env.REACT_APP_PROOF_BUCKET,
+			});
 
-    // the name to save is the id of the experience_01 or whatever the number is.
-    try {
-      let pictureKey = await Storage.put(
-        `${this.props.mongoExperience.id}${this.props.activeExperience.priority}.${fileType[1]}`,
-        file,
-        {
-          bucket: process.env.REACT_APP_PROOF_BUCKET,
-        }
-      );
-      console.log("Key: ", pictureKey);
-      successToast("Proof successfully uploaded.");
-    } catch (e) {
-      errorToast(e);
-    }
-  };
+			console.log('Key: ', pictureKey);
 
-  render() {
-    return (
-      <div>
-        <Modal show={this.props.show} onHide={this.props.handleClose}>
-          <Modal.Header closeButton>
-            <Modal.Title>{I18n.get("submitProof")}</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-            <FormGroup bsSize="large" controlId="athleteNotes">
-              <ControlLabel>{I18n.get("notesForCoach")}</ControlLabel>
-              <FormControl
-                type="text"
-                onChange={this.handleChange}
-                value={this.state.athleteNotes}
-              />
-            </FormGroup>
-            <FormGroup bsSize="large" controlId="github">
-              <ControlLabel>{I18n.get("submitLink")}</ControlLabel>
-              <FormControl
-                type="text"
-                onChange={this.handleChange}
-                value={this.state.github}
-              />
-            </FormGroup>
-            <h3>{I18n.get("attachment")}</h3>
-            <input
-              type="file"
-              accept="image/png"
-              onChange={(evt) => this.onChange(evt)}
-            />
-            <br />
-            <div className="flex">
-              <Button onClick={this.props.handleClose}>
-                {I18n.get("close")}
-              </Button>
-              <LoaderButton
-                block
-                onClick={() => {
-                  this.props.markSubmitted(
-                    this.props.activeExperience,
-                    this.state.github,
-                    this.state.athleteNotes
-                  );
-                  this.setState({
-                    athleteNotes: "",
-                    github: "",
-                  });
-                }}
-                bsSize="large"
-                text={I18n.get("submitProof")}
-                loadingText={I18n.get("saving")}
-                disabled={!this.validateForm()}
-                isLoading={this.state.isChanging}
-              />
-            </div>
-          </Modal.Body>
+			successToast('Proof successfully uploaded.');
+		} catch (err) {
+			errorToast(err);
+		}
+	};
 
-          <Modal.Footer />
-        </Modal>
-      </div>
-    );
-  }
+	return (
+		<div>
+			<Modal show={show} onHide={handleClose}>
+				<Modal.Header closeButton>
+					<Modal.Title>{I18n.get('submitProof')}</Modal.Title>
+				</Modal.Header>
+
+				<Modal.Body>
+					<FormGroup bsSize='large' controlId='athleteNotes'>
+						<ControlLabel>{I18n.get('notesForCoach')}</ControlLabel>
+						<FormControl type='text' onChange={handleChange} value={formData.athleteNotes} />
+					</FormGroup>
+
+					<FormGroup bsSize='large' controlId='github'>
+						<ControlLabel>{I18n.get('submitLink')}</ControlLabel>
+						<FormControl type='text' onChange={handleChange} value={formData.github} />
+					</FormGroup>
+
+					<h3>{I18n.get('attachment')}</h3>
+
+					<input type='file' accept='image/png' onChange={(evt) => onChange(evt)} />
+
+					<br />
+
+					<div className='flex'>
+						<Button onClick={handleClose}>{I18n.get('close')}</Button>
+
+						<LoaderButton
+							block
+							onClick={() => {
+								markSubmitted(activeExperience, formData.github, formData.athleteNotes);
+								setFormData({
+									athleteNotes: '',
+									github: '',
+								});
+							}}
+							bsSize='large'
+							text={I18n.get('submitProof')}
+							loadingText={I18n.get('saving')}
+							disabled={validateForm()}
+							isLoading={isChanging}
+						/>
+					</div>
+				</Modal.Body>
+
+				<Modal.Footer />
+			</Modal>
+		</div>
+	);
 }

--- a/src/learn/NewSubmitProofModal.js
+++ b/src/learn/NewSubmitProofModal.js
@@ -100,7 +100,7 @@ export default function SubmitProof({
 							bsSize="large"
 							text={I18n.get("submitProof")}
 							loadingText={I18n.get("saving")}
-							disabled={validateForm()}
+							disabled={!validateForm()}
 							isLoading={isChanging}
 						/>
 					</div>

--- a/src/libs/s3.js
+++ b/src/libs/s3.js
@@ -1,0 +1,11 @@
+import Storage from "@aws-amplify/storage";
+
+export async function uploadToS3(fileName, file, fileType) {
+	const pictureKey = await Storage.put(`${fileName}.${fileType}`, file, {
+		bucket: process.env.REACT_APP_PROOF_BUCKET,
+	});
+
+	console.log("Key: ", pictureKey);
+
+	return pictureKey;
+}


### PR DESCRIPTION
Converted class components to hooks based on issue #52. I can't really test this component in the browser because I think you need to pay to get access to this page, so I'd be grateful if you could check it out with a paid account(or give me the credentials to that accounts, for testing). Currently, I've checked through the code and there are no errors with SonarLint(IDE plugin) and CRA(create-react-app). 

Also, I'd like to address this todo on line 33:
```javascript
// @TODO: Is this function repetitive? With Arena proof modal?
```

I think it is repetitive and maybe we refactor the following logic into a utility function/service:

```javascript
let pictureKey = await Storage.put(
        `${this.props.sprint.id}_0_${this.props.day}_${this.props.activeIndex}.${fileType[1]}`,
        file,
        {
          bucket: process.env.REACT_APP_PROOF_BUCKET,
        }
);
```

Finally, I've seen several other class based components so let me know if those need to be converted too. Looking forward to your response :)