### PR TITLE
Refactor Leaderboard to use hooks

### DIFF
--- a/src/arena/Sprint.js
+++ b/src/arena/Sprint.js
@@ -516,9 +516,8 @@ function Sprint(props) {
               <div className="col-xs-12 col-sm-6">
                 <Board
                   users={props.redux.sprint[activeSprintId].teams}
-                  paginate={paginate}
-                  setPaginate={setPaginate}
-                  user={props.user}
+                  itemsPerPage={paginate}
+                  currentUser={props.user}
                   history={props.history}
                 />
               </div>

--- a/src/arena/Sprint.js
+++ b/src/arena/Sprint.js
@@ -513,7 +513,7 @@ function Sprint(props) {
           </TabPanel>
           <TabPanel value={key} index={2} style={{ margin: -30 }}>
             <div className="row">
-              <div className="col-xs-12 col-sm-6">
+              <div className="col-xs-12 col-sm-7">
                 <Board
                   users={props.redux.sprint[activeSprintId].teams}
                   itemsPerPage={paginate}
@@ -521,7 +521,7 @@ function Sprint(props) {
                   history={props.history}
                 />
               </div>
-              <div className="col-xs-12 col-sm-6">
+              <div className="col-xs-12 col-sm-5" style={{ marginTop: '20px' }}>
                 <Analytics
                   missions={
                     props.redux.sprint[activeSprintId].teams[index].missions

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { I18n } from "@aws-amplify/core";
 import Table from "react-bootstrap/lib/Table";
+import { ProfileImg } from "./ProfileImg";
 /**
  * @class Leaderboard
  * @TODO Issue #75
@@ -13,12 +14,14 @@ import Table from "react-bootstrap/lib/Table";
 
 function Leaderboard({ users, itemsPerPage, currentUser, history }) {
 
-  const sortedUsers = users.sort((a, b) => a.score - b.score);
+  const sortedUsers = users.sort((a, b) => b.score - a.score);
   const initialRanks = sortedUsers.map((user, i) => {
     user.page = getPage(i + 1); 
     user.rank = i > 0 && user.score == sortedUsers[i - 1].score ? sortedUsers[i - 1].rank : i + 1; 
     return user;
   });
+
+  const topThree = initialRanks.length > 3 ? initialRanks.slice(0,3) : initialRanks.slice(0);
   const currentPage = 1;
   const maxPages = getPage(users.length);
 
@@ -31,14 +34,14 @@ function Leaderboard({ users, itemsPerPage, currentUser, history }) {
    * @desc Sorts the ranking by score either ascending or descending
    */
   function sortUsersByScore() {
-    const tempRanking = [...ranking].sort((a,b) => a.score - b.score);
+    const tempRanking = [...ranking].sort((a,b) => b.score - a.score);
     if (asc) {
-      const newRanking = tempRanking.reverse().map(addPage);
+      const newRanking = tempRanking.map(addPage);
       setAsc(false);
       setRanking(newRanking);
     }
     else {
-      const newRanking = tempRanking.map(addPage);
+      const newRanking = tempRanking.reverse().map(addPage);
       setAsc(true);
       setRanking(newRanking);
     }
@@ -119,69 +122,118 @@ function Leaderboard({ users, itemsPerPage, currentUser, history }) {
   }  
 
   return (
-      <div style={{ margin: '25px' }}>
-      <h2>{I18n.get("leaderboard")}</h2>
-      <form onChange={filterRank} style={{ paddingBottom: '10px' }}>
-        <input className="form-control" type="search" name="search" placeholder="Filter by name..." />
-      </form>
-      <Table bordered condensed hover responsive>
-        <tbody>
-          <tr>
-            <td className="rank-header text-center" onClick={sortUsersByScore}>
-              {" "}
-              {I18n.get("rank")}{" "}
-            </td>
-            <td className="rank-header" onClick={sortUsersByScore}>
-              {" "}
-              {I18n.get("name")}{" "}
-            </td>
-            <td className="rank-header text-center" onClick={sortUsersByScore}>
-              {" "}
-              {I18n.get("score")}{" "}
-            </td>
-          </tr>
-          { ranking.map((user, i) => user.page === pages.currentPage ? 
-            (
-              <tr
-                className={currentUser.id === user.id ? "my-rank" : ""}
-                key={i}
-              >
-                <td className="data text-center">{i > 0 && user.rank == ranking[i - 1].rank ? '-' : user.rank}</td>
-                <td
-                  onClick={() =>
-                    history.push(`/profile/${user.id}`)
-                  }
-                  className="data2"
-                >
-                  {user.fName} {user.lName.substr(0,1).toUpperCase()}.
-                </td>
-                <td className="data text-center">{user.score} pts</td>  
-              </tr>
-            ) : null 
-          )}
-        </tbody>
-      </Table>
-      <div style={{ display: "flex", justifyContent: "space-between" }}>
-        {pages.currentPage <= 1 ? null : (
-          <p className="decrement" onClick={decreasePage}>
-            {I18n.get("back")}
-          </p>
-        )}
-        {pages.currentPage <= 1 ? null : (
-          <p onClick={decreasePage}> {pages.currentPage - 1}</p>
-        )}
-        {pages.maxPages == 1 ? null : <p> {pages.currentPage}</p>}
-        {pages.currentPage < pages.maxPages ? (
-          <p onClick={increasePage}> {pages.currentPage + 1}</p>
-        ) : null}
-        {pages.currentPage < pages.maxPages ? (
-          <p className="increment" onClick={increasePage}>
-            {I18n.get("next")}
-          </p>
-        ) : null }
+      <div style={{ margin: '25px 10px' }}>
+        <h2>{I18n.get("leaderboard")}</h2>
+        <div className="leaderboard-container">
+          <Podium topUsers={topThree}></Podium>
+          <div className="table-container" style={{flexShrink: "1"}}>
+            <form onChange={filterRank} style={{ paddingBottom: '10px' }}>
+              <input className="form-control" type="search" name="search" placeholder="Filter by name..." />
+            </form>
+            <Table bordered condensed hover responsive>
+              <tbody>
+                <tr>
+                  <td className="rank-header text-center" onClick={sortUsersByScore}>
+                    {" "}
+                    {I18n.get("rank")}{" "}
+                  </td>
+                  <td className="rank-header" onClick={sortUsersByScore}>
+                    {" "}
+                    {I18n.get("name")}{" "}
+                  </td>
+                  <td className="rank-header text-center" onClick={sortUsersByScore}>
+                    {" "}
+                    {I18n.get("score")}{" "}
+                  </td>
+                </tr>
+                { ranking.map((user, i) => user.page === pages.currentPage ? 
+                  (
+                    <tr
+                      className={currentUser.id === user.id ? "my-rank" : ""}
+                      key={i}
+                    >
+                      <td className="data text-center">{i > 0 && user.rank == ranking[i - 1].rank ? '-' : user.rank}</td>
+                      <td
+                        onClick={() =>
+                          history.push(`/profile/${user.id}`)
+                        }
+                        className="data2"
+                      >
+                        {user.fName} {user.lName.substr(0,1).toUpperCase()}.
+                      </td>
+                      <td className="data text-center">{user.score} pts</td>  
+                    </tr>
+                  ) : null 
+                )}
+              </tbody>
+            </Table>
+            <div style={{ display: "flex", justifyContent: "space-between" }}>
+              {pages.currentPage <= 1 ? null : (
+                <p className="decrement" onClick={decreasePage}>
+                  {I18n.get("back")}
+                </p>
+              )}
+              {pages.currentPage <= 1 ? null : (
+                <p onClick={decreasePage}> {pages.currentPage - 1}</p>
+              )}
+              {pages.maxPages == 1 ? null : <p> {pages.currentPage}</p>}
+              {pages.currentPage < pages.maxPages ? (
+                <p onClick={increasePage}> {pages.currentPage + 1}</p>
+              ) : null}
+              {pages.currentPage < pages.maxPages ? (
+                <p className="increment" onClick={increasePage}>
+                  {I18n.get("next")}
+                </p>
+              ) : null }
+            </div>
+          </div>
+        </div>
+      </div>
+  );
+}
+
+function Podium({topUsers}) {
+
+  const sortedTopUsers = [];
+  topUsers.forEach((user, i) => {
+    i % 2 > 0 ? sortedTopUsers.push(user) : sortedTopUsers.unshift(user);
+  })
+
+  return (
+    <div className="podium-padding-wrapper">
+      <div className="podium-container">
+        {sortedTopUsers.map((user, i) => <Dais key={i} id={i} user={user} rank={user.rank} ranks={topUsers.length} />)}
       </div>
     </div>
-  );
+  )
+
+}
+
+function Dais({user, rank, ranks}) {
+
+  const platformWidth = Math.round(100 / ranks);
+  const platformHeight = Math.round(200 * (ranks - rank + 2) / (ranks * 3 + 3));
+  const profileHeight = (100 - platformHeight) + '%';
+  const altProfileHeight = Math.round(200 * (rank - 1) / (ranks * 3 + 3)) + '%';
+  const profileHeightCalc = "calc(min(80px + "+altProfileHeight+", " + profileHeight + "))";
+
+    return (
+      <div className="podium-dais" style={{ width: platformWidth + "%" }}>
+        <div style={{ height: "100%" , width: "100%" }}>
+          <div className="dais-user" style={{ height: profileHeightCalc }}>
+            <div className="dais-image-container">
+              <div className="dais-image-lockup">
+                <ProfileImg profileImg={user.profileImg ? user.profileImg : null} />
+                <div className="dais-image-label" style={{ verticalAlign: "middle", textAlign: "center"}}>
+                  {user.fName}
+                </div>
+              </div>
+            </div> 
+          </div>
+          <div className="dais-platform" style={{ height: platformHeight + "%" }}>{rank}</div>
+        </div>
+      </div>
+    )
 }
 
 export default Leaderboard;

--- a/src/components/PageNavigation.js
+++ b/src/components/PageNavigation.js
@@ -1,0 +1,50 @@
+import { I18n } from "@aws-amplify/core";
+
+/**
+ * @component PageNavigation
+ * @desc Displays options for navigating through a paginated list
+ * @param {Prop} currentPage-the current page of results
+ * @param {Prop} maxPages-the total number of possible pages of results
+ * @param {Prop} increasePage-function to increase the currentPage by 1
+ * @param {Prop} decreasePage-function ot decrease the currentPage by 1
+ */
+export function PageNavigation({currentPage, maxPages, increasePage, decreasePage}) {
+
+    const [nextPage, priorPage] = [currentPage + 1, currentPage - 1];
+
+    return (
+        <div style={{ display: "flex", justifyContent: "center", fontSize: "12px" }}>
+        {currentPage <= 1 ? 
+            <HiddenNav id="back" label={"< " + I18n.get("back")} /> : 
+            <VisibleNav id="back" handleClick={decreasePage} label={"< " + I18n.get("back")} />
+        }
+        {currentPage <= 1 ? 
+            <HiddenNav id={"page-" + priorPage} label={priorPage} /> :
+            <VisibleNav id={"page-" + priorPage} handleClick={decreasePage} label={priorPage} /> 
+        }
+        {maxPages == 1 ? 
+            <HiddenNav id="current-page" label={currentPage} /> :
+            <VisibleNav id="current-page" label={null} handleClick={null}>
+                <span style={{ fontWeight: "bold", cursor: "default", backgroundColor: "lightgray", padding: "5px 10px", borderRadius: "10px" }}>{currentPage}</span>
+            </VisibleNav>
+        }
+        {currentPage < maxPages ? 
+            <VisibleNav id={"page-" + nextPage} handleClick={increasePage} label={nextPage} /> :
+            <HiddenNav id={"page-" + nextPage} label={nextPage > maxPages ? null : nextPage} />
+        }
+        {currentPage < maxPages ? 
+            <VisibleNav id="next" handleClick={increasePage} label={I18n.get("next") + " >"} /> : 
+            <HiddenNav id="next" label={I18n.get("next") + " >"} />
+        }
+      </div>
+    
+    )
+}
+
+function VisibleNav({ handleClick, label, children }) {
+    return (<p style={{ cursor: "pointer", padding: "0px 15px" }} onClick={handleClick}>{label || children}</p>)
+}
+
+function HiddenNav({ label, children }) {
+    return (<p style={{ opacity: "0.6", padding: "0px 15px" }}>{label || children}</p>)
+}

--- a/src/components/ProfileImg.js
+++ b/src/components/ProfileImg.js
@@ -1,0 +1,13 @@
+export function ProfileImg({ profileImg }) {
+    return (
+        <div className="dais-image">
+        {profileImg ? 
+            <img src={profileImg} width="100%" height="100%" /> : 
+            <>
+                <div style={{backgroundColor: "white", borderRadius: "50%", width: "34%", height: "34%", transform: "translate(97%, 80%)"}}></div>
+                <div style={{backgroundColor: "white", borderRadius: "50%",  width: "50%", height: "80%", transform: "translate(50%, 40%)"}}></div>
+            </>
+        }
+      </div>
+    )
+}

--- a/src/components/ProfileImg.js
+++ b/src/components/ProfileImg.js
@@ -1,6 +1,11 @@
+/**
+ * @component ProfileImage
+ * @desc Displays either the user's current profile image or a generic image if none exists
+ * @param {Prop} profileImg-the profile image object
+ */
 export function ProfileImg({ profileImg }) {
     return (
-        <div className="dais-image">
+        <div className="profile-image">
         {profileImg ? 
             <img src={profileImg} width="100%" height="100%" /> : 
             <>

--- a/src/index.css
+++ b/src/index.css
@@ -368,11 +368,102 @@ input[type="file"] {
 
 /* Leaderboard styles */
 
+.leaderboard-container {
+	display: flex;
+	justify-content: stretch;
+	flex-wrap: wrap;
+	width: 100%;
+	min-width: 300px;
+}
+
+.podium-padding-wrapper {
+	max-height: 230px;
+	min-width: 230px;
+	max-width: 530px;
+	flex-grow: 1;
+	position: relative;
+	padding-bottom: calc(min(230px,100%));
+	margin: 0px calc(max(5px, min(7%, 20px)));
+}
+
+.podium-container {
+	position: absolute;
+	width: 100%;
+	height: calc(min(230px, 100%));
+	display: flex;
+	flex-wrap: nowrap;
+	align-content: center;
+}
+
+.podium-dais {
+	display: flex;
+	align-content: flex-end;
+	align-items: flex-end;
+	margin-bottom: 15px;
+}
+
+.dais-user {
+	width: 100%;
+	display: flex;
+	justify-content: center;
+	align-items: flex-end;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.dais-image-container {
+	position: relative;
+	top: 10px;
+	width: 100%;
+	max-width: 80px;
+	padding-bottom: calc(min(80px, 100%));
+}
+
+.dais-image-lockup {
+	position: absolute;
+	width: 100%;
+	height: 100%;
+}
+
+.dais-image {
+	width: calc(100% - 30px);
+	height: calc(100% - 30px);
+	margin: 0px 15px;
+	border-radius: 50%;
+	border: 1px solid gray;
+	background-color: lightgray;
+	overflow: hidden;
+}
+
+.dais-image-label {
+	width: 100%;
+	height: 20px;
+	font-size: 14px;
+}
+
+.dais-platform {
+	background-color: rgb(90, 186, 233);
+	padding: 10%;
+	text-align: center;
+	font-size: 3rem;
+	color: #fff;
+	margin: 0px calc(max(5px, 8%));
+}
+
+.table-container {
+	min-width: 300px;
+	max-width: 570px;
+	flex-grow: 1;
+	flex-shrink: 1;
+}
+
 .rank-header {
 	color: rgb(37, 38, 39);
 	background-color: #eee;
 	font-size: 16px;
 	font-weight: bold;
+	cursor: pointer;
 }
 
 .data:first-child {
@@ -390,11 +481,11 @@ input[type="file"] {
 }
 
 .my-rank {
-	background-color: rgb(0, 170, 212);
+	background-color: rgb(90, 186, 233);
 }
 
 .my-rank:hover {
-	background-color: rgb(0, 185, 231)!important;
+	background-color: rgb(139, 207, 241)!important;
 }
 
 .fake-bullet {

--- a/src/index.css
+++ b/src/index.css
@@ -426,7 +426,7 @@ input[type="file"] {
 	height: 100%;
 }
 
-.dais-image {
+.profile-image {
 	width: calc(100% - 30px);
 	height: calc(100% - 30px);
 	margin: 0px 15px;

--- a/src/index.css
+++ b/src/index.css
@@ -370,12 +370,18 @@ input[type="file"] {
 
 .rank-header {
 	color: rgb(37, 38, 39);
-	font-size: 20px;
+	background-color: #eee;
+	font-size: 16px;
 	font-weight: bold;
 }
+
 .data:first-child {
-	font-size: 18px;
+	font-size: 16px;
 	font-weight: bold;
+}
+
+.data, .data2 {
+	font-size: 16px;
 }
 
 .data2:hover {
@@ -385,6 +391,10 @@ input[type="file"] {
 
 .my-rank {
 	background-color: rgb(0, 170, 212);
+}
+
+.my-rank:hover {
+	background-color: rgb(0, 185, 231)!important;
 }
 
 .fake-bullet {


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Pull-Request for `paretOS`

## Description
Enhances Leaderboard appearance (leaderboard logic/ranking/score attribution will be addressed in a separate PR.)

- [X] Remove the references to 'orderByName' and generally simplify/consolidate the code needed for the component to run.
- [X] Refactor into a Hook
- [X] Test how the component handles more than 10 users at once - what if you are ranked number 27 out of 34 - should the leaderboard default to your place in the hierarchy? Probably. _(Note: this is set up to default to the user's page in the rankings.)_
- [X] Update the UI a bit - add an olympic podium of sorts. _(Note: Basic podium implemented, styling can be improved in the future. Podium will only display if any participant has a score > 0, podium can be set up to not display ranks of users with null scores)_
- [X] This leaderboard needs to be slightly flexible, in that we want to be able to perhaps search for a particular member to see their score - maybe a search box is a good thing. _(Note: this can be accomplished by using the filter, which now has improved functionality. Unless there is another use case for searching/filtering that I'm not catching?)_
- [ ] We want to be able to pass some props in to modify the purpose/UI of the leaderboard - it needs to be able to be active in a global competition context, a local context or an industry/vertical context. 

Additional improvements:
- [X] Add minor enhancements to existing styling
- [X] Fix hover color for my-rank class to match logo
- [X] Fix padding & font size
- [X] Hide page navigation controls when maxPages = 1
- [X] Fix ranking for identical scores
- [X] Fix rank display for identical ranks
- [X] Carve out PageNavigation and ProfilePic components so they can be used elsewhere in app

## Relates to
Partially addresses #75 

### Screenshots / other info

![leaderboard](https://user-images.githubusercontent.com/84106309/140836480-24cfbde1-55fd-42a6-83f5-d9c70bb233d0.gif)

![pagination](https://user-images.githubusercontent.com/84106309/140849545-2674f2a8-656d-45a9-8b66-90b74b499a1c.gif)

