### PR TITLE
Chore/fix console errors

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -566,7 +566,6 @@ class App extends Component {
               disableEscapeKeyDown
               fullScreen
               fullWidth
-              disableBackdropClick
               hideBackdrop={false}
               aria-labelledby="loading"
               aria-describedby="Please wait while the page loads"

--- a/src/components/LeftNav.js
+++ b/src/components/LeftNav.js
@@ -54,7 +54,6 @@ function LeftNav(props) {
       >
         <div style={{ marginLeft: 4 }}>
           <MenuItem
-            exact
             key={1.1}
             onClick={() => {
               I18n.setLanguage("lg");
@@ -71,7 +70,6 @@ function LeftNav(props) {
             &ensp; Luganda
           </MenuItem>
           <MenuItem
-            exact
             key={1.2}
             onClick={() => {
               I18n.setLanguage("es");
@@ -88,7 +86,6 @@ function LeftNav(props) {
             &ensp; Spanish
           </MenuItem>
           <MenuItem
-            exact
             key={1.3}
             onClick={() => {
               I18n.setLanguage("en");
@@ -106,7 +103,6 @@ function LeftNav(props) {
           </MenuItem>
 
           <MenuItem
-            exact
             key={1.4}
             onClick={() => {
               I18n.setLanguage("ptbr");
@@ -124,7 +120,6 @@ function LeftNav(props) {
           </MenuItem>
 
           <MenuItem
-            exact
             key={1.5}
             onClick={() => {
               I18n.setLanguage("ngpg");
@@ -142,7 +137,6 @@ function LeftNav(props) {
           </MenuItem>
 
           <MenuItem
-            exact
             key={1.6}
             onClick={() => {
               I18n.setLanguage("hi");

--- a/src/components/LeftNav.js
+++ b/src/components/LeftNav.js
@@ -125,7 +125,7 @@ function LeftNav(props) {
 
           <MenuItem
             exact
-            key={1.4}
+            key={1.5}
             onClick={() => {
               I18n.setLanguage("ngpg");
               updateState({
@@ -143,7 +143,7 @@ function LeftNav(props) {
 
           <MenuItem
             exact
-            key={1.5}
+            key={1.6}
             onClick={() => {
               I18n.setLanguage("hi");
               updateState({

--- a/src/learn/ExperienceModule.js
+++ b/src/learn/ExperienceModule.js
@@ -56,6 +56,7 @@ class ExperienceModule extends Component {
         id: "",
       },
       openReviewModal: false,
+      showPaywallDialog: this.props.user.learningPurchase === false,
       experienceId: "",
       // this shows the proof submission modal, which needs work
       showSubmitModal: false,
@@ -476,19 +477,24 @@ class ExperienceModule extends Component {
             style={{
               margin: "auto",
             }}
-            open={this.props.user.learningPurchase === false}
+            open={this.state.showPaywallDialog}
             TransitionComponent={Transition}
             keepMounted
-            disableEscapeKeyDown
-            disableBackdropClick
             hideBackdrop={false}
             aria-labelledby="loading"
             aria-describedby="Please wait while the page loads"
+            onClose={(event, reason) => {
+              if (
+                reason !== "backdropClick" &&
+                reason !== "escapeKeyDown" &&
+                this.props.user.learningPurchase === false
+              ) {
+                this.setState({ ...this.state, showPaywallDialog: false });
+                history.push("/");
+              }
+            }}
           >
-            <PaywallModal
-              {...this.props}
-              open={this.props.user.learningPurchase}
-            />
+            <PaywallModal {...this.props} open={this.state.showPaywallDialog} />
           </Dialog>
         </div>
         {this.state.isLoading === true ? (

--- a/src/learn/LearnDashboard.js
+++ b/src/learn/LearnDashboard.js
@@ -22,6 +22,9 @@ const Transition = React.forwardRef(function Transition(props, ref) {
 
 function LearnDashboard(props) {
   const [html, setHtml] = useState(null);
+  const [showPaywallDialog, setShowPaywallDialog] = useState(
+    props.user.learningPurchase === false
+  );
 
   useEffect(() => {
     if (html === null) {
@@ -108,16 +111,20 @@ function LearnDashboard(props) {
         style={{
           margin: "auto",
         }}
-        open={props.user.learningPurchase === false}
+        open={showPaywallDialog}
         TransitionComponent={Transition}
         keepMounted
-        disableEscapeKeyDown
-        disableBackdropClick
         hideBackdrop={false}
         aria-labelledby="loading"
         aria-describedby="Please wait while the page loads"
+        onClose={(event, reason) => {
+          if (reason !== "backdropClick" && reason !== "escapeKeyDown") {
+            setShowPaywallDialog(false);
+            history.push("/");
+          }
+        }}
       >
-        <PaywallModal {...props} open={props.user.learningPurchase} />
+        <PaywallModal {...props} open={showPaywallDialog} />
       </Dialog>
     </div>
   );

--- a/src/learn/PaywallModal.js
+++ b/src/learn/PaywallModal.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from "react";
-import { useHistory } from "react-router-dom";
 import { DialogContent } from "@mui/material";
 import Button from "react-bootstrap/lib/Button";
 import Order from "./Order";
@@ -21,21 +20,7 @@ function LoadingModal(props) {
 
   const [showPayment, setShowPayment] = useState(false);
 
-  const history = useHistory();
   const modalRef = useRef();
-
-  useEffect(() => {
-    let handleModalClose = (event) => {
-      if (props.open === false && !modalRef.current?.contains(event.target)) {
-        history.push("/");
-      }
-    };
-    document.addEventListener("mousedown", handleModalClose);
-
-    return () => {
-      document.removeEventListener("mousedown", handleModalClose);
-    };
-  }, [showPayment]);
 
   return (
     <>


### PR DESCRIPTION
Pull-Request for `paretOS`

## Description
Fixes browser console error messages to make it easier to see when new errors are introduced
- [X] 'Duplicate key' - A MenuItem in the language dropdown of LeftNav was copy-pasted, so there was a duplicate key created. Easy fix.
- [X] 'Received boolean value for non-boolean property exact' - the MenuItem components in the language dropdown were being passed the "exact" property. This doesn't seem to be a valid prop for MenuItem components in React Bootstrap. Removing it resolved the error. 
- [X] 'disableBackdropClick' - Prop no longer exists. Removed from App.js (there is no backdrop visible to click on) and refactored in `LearnDashboard` & `ExperienceModule`.

## Relates to
- Partially fixes #142 

## Reviewers
- @mikhael28  (merge duty)

## Steps to reproduce (if describing bug fix)
See chore description #142 

### Screenshots / other info
No more console errors showing! 
<img width="1148" alt="Screen Shot 2022-03-20 at 1 14 04 PM" src="https://user-images.githubusercontent.com/84106309/159174305-a82d4cf5-8814-4d42-b990-e04971824343.png">

