### PR TITLE
Fix console errors

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -76,6 +76,7 @@ class App extends Component {
       sanityTraining: [],
       sanityProduct: [],
       sanityInterview: [],
+      dialogOpen: true,
     };
     // this.wsClient = "";
   }
@@ -490,6 +491,34 @@ class App extends Component {
       sanitySchemas: this.state.sanitySchemas,
       coaches: this.state.coaches,
     };
+
+    function DialogMigrate({
+      children,
+      disableBackdropClick,
+      disableEscapeKeyDown,
+      onClose,
+      ...rest
+    }) {
+      const handleClose = (event, reason) => {
+        if (disableBackdropClick && reason === "backdropClick") {
+          return false;
+        }
+
+        if (disableEscapeKeyDown && reason === "escapeKeyDown") {
+          return false;
+        }
+
+        if (typeof onClose === "function") {
+          onClose();
+        }
+      };
+
+      return (
+        <Dialog onClose={handleClose} {...rest}>
+          {children}
+        </Dialog>
+      );
+    }
     return (
       !this.state.isAuthenticating && (
         <Sentry.ErrorBoundary
@@ -556,7 +585,7 @@ class App extends Component {
               onRequestClose={this.closeTour}
               showCloseButton
             />
-            <Dialog
+            <DialogMigrate
               style={{
                 margin: "auto",
               }}
@@ -564,15 +593,19 @@ class App extends Component {
               TransitionComponent={Transition}
               keepMounted
               disableEscapeKeyDown
+              disableBackdropClick
               fullScreen
               fullWidth
-              disableBackdropClick
+              onClose={() => {
+                // Whatever you want to run here on close.
+                this.state.dialogOpen = true;
+              }}
               hideBackdrop={false}
               aria-labelledby="loading"
               aria-describedby="Please wait while the page loads"
             >
               <LoadingModal />
-            </Dialog>
+            </DialogMigrate>
           </>
         </Sentry.ErrorBoundary>
       )


### PR DESCRIPTION
-fix: Create a wrapper for Dialog component to fix `disableBackDropClick` deprecation errror.

Pull-Request for `paretOS`

## Description
When the page loaded, the browser was showing an `disableBackDropClick` error.
That was happening because the prop `disableBackDropClick` is deprecated and has been made redundant. To make it work, it's necessary to pass the funcion "onClose" together with the props.
After some searching, the solution that I found was creating a wrapper for the Dialog.
I tested it and it worked completely fine, no errors in the console.

## Relates to
- #142 

## Reviewers
- @jayeclark 

## Screenshots
![Screenshot_1](https://user-images.githubusercontent.com/59806140/159176721-f55dc63a-2df6-4972-ad25-79261d7dbdce.png)

## Notes
I'm sorry if I did anything wrong, that's my second time ever contributing to open-source projects in GitHub. Please tell me if I did anything wrong.
