### PR TITLE
Fix/refactor leaderboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@sanity/image-url": "^1.0.1",
     "@sentry/react": "^6.18.2",
     "@sentry/tracing": "^6.18.2",
+    "@testing-library/jest-dom": "^5.16.2",
+    "@testing-library/react": "^12.1.4",
     "classnames": "^2.3.1",
     "flutterwave-react-v3": "^1.2.0",
     "history": "^5.3.0",
@@ -79,8 +81,6 @@
   ],
   "devDependencies": {
     "@mui/types": "^7.1.3",
-    "@testing-library/jest-dom": "^5.16.2",
-    "@testing-library/react": "^12.1.4",
     "@types/jest": "^27.0.2",
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.30",

--- a/src/components/Board.spec.tsx
+++ b/src/components/Board.spec.tsx
@@ -3,31 +3,59 @@ import "@testing-library/jest-dom";
 import Leaderboard from "./Board";
 import type { User } from "../types";
 
-describe("sortUsersByScore", () => {
+describe("LEADERBOARD", () => {
   const users = testUsers();
-  beforeEach(() => {
-    render(
-      <Leaderboard
-        users={users}
-        itemsPerPage={3}
-        currentUser={users[5]}
-        history={[]}
-      />
-    );
+
+  describe("Leaderboard Table:", () => {
+    beforeEach(() => {
+      render(
+        <Leaderboard
+          users={users}
+          itemsPerPage={3}
+          currentUser={users[5]}
+          history={[]}
+        />
+      );
+    });
+    it("displays a leaderboard table", () => {
+      expect(screen.getByTitle("Leaderboard")).toBeDefined();
+    });
+    it("displays the page of the table containing the current user", () => {
+      expect(screen.getByText("Current U.")).toBeDefined();
+    });
+    it("displays a table with three users if itemsperpage is set to 3 users", () => {
+      expect(screen.getAllByTestId("leaderboard-row").length).toEqual(3);
+    });
+    // TODO: add test. "correctly increments and decrements pages"
+    // TODO: add test. "initially displays the leaderboard table in descending score order"
+    // TODO: add test. "reacts to a click on the "name" column header by sorting the initial state leaderboard table by descending name order"
+    // TODO: add test. "reacts to a click on "score" column header by sorting the initial state leaderboard table by ascending score order"
+    // TODO: add test. "reacts to a click on the "rank" column header by sorting the initial state leaderboard by ascending score order"
+    // TODO: add test. "reacts intelligently to new sortby properties. if descending score order is also descending name order, clicking the 'name' column results in sorting by ascending name order."
+    // TODO: add test. "correctly filters the user array based on a given filter phrase."
+    // TODO: add test. "filters according to a combination of first name plus the first letter of last name. ('John S.' would fit the filter 's'.)"
   });
-  it("displays a leaderboard list", () => {
-    expect(screen.getByTitle("Leaderboard")).toBeDefined();
-  });
-  it("displays the current user", () => {
-    expect(screen.getByText("Current U.")).toBeDefined();
-  });
-  it("displays a table with three users", () => {
-    expect(screen.getAllByTestId("leaderboard-row").length).toEqual(3);
-  });
-  it("displays a podium with the top three users", () => {
-    expect(screen.getByText("First")).toBeDefined();
-    expect(screen.getByText("Second")).toBeDefined();
-    expect(screen.getByText("Third")).toBeDefined();
+
+  describe("Leaderboard Podium:", () => {
+    beforeEach(() => {
+      render(
+        <Leaderboard
+          users={users}
+          itemsPerPage={3}
+          currentUser={users[5]}
+          history={[]}
+        />
+      );
+    });
+    it("displays a podium with the top three users", () => {
+      expect(screen.getByText("First")).toBeDefined();
+      expect(screen.getByText("Second")).toBeDefined();
+      expect(screen.getByText("Third")).toBeDefined();
+    });
+    // TODO: add test. "displays 3 different podiums of varying heights"
+    // TODO: add test. "displays the #1 scoring user on the tallest podium"
+    // TODO: add test. "displays the #3 scoring user on the shorted podium"
+    // TODO: add test. "does not display the podiums if the viewport width is less than a certain value." (Use jestdom and getcomputedstyle?)
   });
 });
 

--- a/src/components/Board.spec.tsx
+++ b/src/components/Board.spec.tsx
@@ -55,7 +55,7 @@ describe("LEADERBOARD", () => {
     // TODO: add test. "displays 3 different podiums of varying heights"
     // TODO: add test. "displays the #1 scoring user on the tallest podium"
     // TODO: add test. "displays the #3 scoring user on the shorted podium"
-    // TODO: add test. "does not display the podiums if the viewport width is less than a certain value." (Use jestdom and getcomputedstyle?)
+    // TODO: add test. "does not display the podiums if no user has a score greater than 0."
   });
 });
 

--- a/src/components/Board.spec.tsx
+++ b/src/components/Board.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import Leaderboard, { User } from "./Board";
+import Leaderboard from "./Board";
+import type { User } from "../types";
 
 describe("sortUsersByScore", () => {
   const users = testUsers();
@@ -33,7 +34,6 @@ describe("sortUsersByScore", () => {
 function testUsers(): Array<User> {
   const users: Array<User> = [
     {
-      page: 1,
       rank: 1,
       score: 1000,
       id: 1,
@@ -48,7 +48,6 @@ function testUsers(): Array<User> {
       review: "123",
     },
     {
-      page: 1,
       rank: 2,
       score: 900,
       id: 2,
@@ -63,7 +62,6 @@ function testUsers(): Array<User> {
       review: "123",
     },
     {
-      page: 1,
       rank: 3,
       score: 800,
       id: 3,
@@ -78,7 +76,6 @@ function testUsers(): Array<User> {
       review: "123",
     },
     {
-      page: 2,
       rank: 4,
       score: 700,
       id: 4,
@@ -93,7 +90,6 @@ function testUsers(): Array<User> {
       review: "123",
     },
     {
-      page: 2,
       rank: 5,
       score: 600,
       id: 5,
@@ -108,7 +104,6 @@ function testUsers(): Array<User> {
       review: "123",
     },
     {
-      page: 2,
       rank: 6,
       score: 500,
       id: 6,

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from "react";
 import { I18n } from "@aws-amplify/core";
 import Table from "react-bootstrap/lib/Table";
+import { User } from "../types";
 import ProfileImg from "./ProfileImg";
 import PageNavigation from "./PageNavigation";
 
@@ -14,35 +15,12 @@ import PageNavigation from "./PageNavigation";
  * @param {Prop} history-array of recent pages/views visited
  */
 
-interface PlanningField {
-  name: string;
-  code: string;
-  content: string;
-}
-
-export type User = {
-  page: number;
-  rank: number;
-  score: number;
-  id: number;
-  fName: string;
-  lName: string;
-  email: string;
-  github: string;
-  missions: Array<Object>;
-  percentage: number;
-  phone: string;
-  planning: Array<PlanningField>;
-  review: string;
-  profileImg?: File;
-};
-
-export interface BoardProps {
+export type BoardProps = {
   users: Array<User>;
   itemsPerPage: number;
   currentUser: User;
   history: Array<String>;
-}
+};
 
 function Leaderboard({
   users,
@@ -309,7 +287,7 @@ function Podium({ topUsers, removeNullScores }: PodiumProps) {
             key={user.id}
             id={i}
             user={user}
-            rank={user.rank}
+            rank={user.rank || 1}
             ranks={topUsers.length}
           />
         ))}

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -29,7 +29,7 @@ function Leaderboard({
   history,
 }: BoardProps) {
   // Set state for leaderboard rankings and display order, calculate users for podium
-  const sortedUsers = users.sort(sortDescending);
+  const sortedUsers = [...users.sort(sortDescending)];
   const initialRanks = sortedUsers.map((user, i) => {
     user.page = getPage(i + 1);
     user.rank =

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -28,112 +28,109 @@ function Leaderboard({
   currentUser,
   history,
 }: BoardProps) {
-  // Set state for leaderboard rankings and display order, calculate users for podium
-  const sortedUsers = [...users.sort(sortDescending)];
-  const initialRanks = sortedUsers.map((user, i) => {
-    user.page = getPage(i + 1);
+  // Define users to show on podium
+  const podiumCount = 3;
+
+  // Sort a copy of the user array and add rankings
+  const sortedUsers = [...users].sort((a, b) => b.score - a.score);
+  const rankedUsers = sortedUsers.map((user, i) => {
     user.rank =
       // eslint-disable-next-line eqeqeq
-      i > 0 && user.score == sortedUsers[i - 1].score
+      i > 0 && user.score === sortedUsers[i - 1].score
         ? sortedUsers[i - 1].rank
         : i + 1;
     return user;
   });
-  const topThree =
-    initialRanks.length > 3 ? initialRanks.slice(0, 3) : initialRanks.slice(0);
-  const [ranking, setRanking] = useState(initialRanks);
-  const [asc, setAsc] = useState(false);
 
-  // Set state for results page
-  const maxPages = getPage(users.length);
-  const currentPage = getPage(
-    initialRanks.findIndex(({ id }) => id === currentUser.id) + 1
+  // Determine who should appear on the podium
+  const topUsers = rankedUsers.slice(0, podiumCount);
+
+  // Get curent user page. Will return -1 if user is not in filtered user array
+  const currentUserPage = getPage(
+    rankedUsers.findIndex(({ id }) => id === currentUser.id)
   );
-  const [pages, setPages] = useState({ currentPage, maxPages });
+
+  // Manage three state variables: sort property & order, filter phrase, and page to display
+  const [sortBy, setSortBy] = useState({ property: "score", ascending: false });
+  const [filterBy, setFilterBy] = useState("");
+  const [page, setPage] = useState(Math.max(currentUserPage, 1));
 
   /**
-   * @function sortDescending
-   * @desc Sorts the ranking by score, in descending order
+   * @function maxPages
+   * @desc Getter for the maximum number of pages given filtered user array length
    */
-  function sortDescending(a: User, b: User) {
-    return b.score - a.score;
+  const maxPages = () => getPage(rankedUsers.filter(filterUsers).length);
+
+  /**
+   * @function handleSortChange
+   * @desc Callback to sort two users by score or name, in ascending or descending order
+   */
+  function handleSortChange(e: React.MouseEvent<HTMLElement>) {
+    const property: string = (e.target as HTMLElement).id;
+    const { ascending } = sortBy;
+    // Check to see if the array is already sorted in order by the new property
+    const sorted = rankedUsers.sort(sortUsers).filter(filterUsers);
+
+    let alreadySorted = sorted
+      .slice(1)
+      .every((x, i) => x[property] <= sorted[i][property]);
+    if (ascending) {
+      alreadySorted = sorted
+        .slice(1)
+        .every((x, i) => x[property] >= sorted[i][property]);
+    }
+    // If there is a change in sort property, and doing so in the current order would result in changes, update only the propery
+    if (property !== sortBy.property && alreadySorted === false) {
+      setSortBy({ property, ascending });
+      return;
+    }
+
+    // Otherwise, change the order of the sort (property may or may not change)
+    setSortBy({ property, ascending: !ascending });
   }
 
   /**
-   * @function sortUsersByScore
-   * @desc Sorts the ranking by score either ascending or descending
+   * @function sortUsers
+   * @desc Callback to sort two users by score or name, in ascending or descending order
    */
-  function sortUsersByScore() {
-    const tempRanking: Array<User> = [...ranking].sort(sortDescending);
-    if (asc) {
-      const newRanking: Array<User> = tempRanking.map(addPage);
-      setAsc(false);
-      setRanking(newRanking);
-    } else {
-      const newRanking = tempRanking.reverse().map(addPage);
-      setAsc(true);
-      setRanking(newRanking);
-    }
+  function sortUsers(a: User, b: User): number {
+    const { ascending, property } = sortBy;
+    if (ascending && a[property] < b[property]) return -1;
+    if (ascending && a[property] > b[property]) return 1;
+    if (ascending === false && b[property] < a[property]) return -1;
+    if (ascending === false && b[property] > a[property]) return 1;
+    return 0;
   }
 
   /**
-   * @function filterRank
-   * @desc Filters through the ranking to find matches and sorts all matches by score
-   * @param {String} search input
+   * @function filterUsers
+   * @desc Filters each element of a user array based on a search string
+   * @param {User} x user to evaluate
    */
-  function filterRank(e: React.FormEvent<HTMLFormElement>) {
-    const input: any = e.currentTarget;
-    const inputLength: number = input?.value.length;
-    const filteredRanking: Array<User> = [];
-    if (inputLength > 0) {
-      users.forEach((user) => {
-        const str = user.fName.substring(0, inputLength).toLowerCase();
-        if (str === input?.value.toLowerCase()) {
-          filteredRanking.push(user);
-        }
-      });
-      filteredRanking.sort((a, b) =>
-        asc ? a.score - b.score : b.score - a.score
-      );
-      const newRanking = filteredRanking.map(addPage);
-      const [currentPage, maxPages] = [1, getPage(newRanking.length)];
-      setRanking(newRanking);
-      setPages({ currentPage, maxPages });
-    } else {
-      const newRanking = users.map(addPage);
-      setRanking(newRanking);
-      setPages({
-        currentPage: getPage(
-          initialRanks.findIndex(({ id }) => id === currentUser.id)
-        ),
-        maxPages: getPage(users.length),
-      });
-    }
+  function filterUsers(x: User): boolean {
+    const name: string = (x.fName + x.lName.substring(0, 1)).toLowerCase();
+    return name.includes(filterBy.toLowerCase());
   }
 
   /**
    * @function increasePage
-   * @desc Increments page by one
+   * @desc Increments page
    * @param {Event} Click
    */
-  function increasePage() {
-    let { currentPage, maxPages } = pages;
-    if (currentPage < maxPages) {
-      currentPage += 1;
-      setPages({ currentPage, maxPages });
+  function increasePage(e, num: number = 1) {
+    if (page + num <= maxPages()) {
+      setPage(page + num);
     }
   }
 
   /**
    * @function decreasePage
-   * @desc Decrements page by one
+   * @desc Decrements page
    * @param {Event} Click
    */
-  function decreasePage() {
-    let { currentPage, maxPages } = pages;
-    if (currentPage > 1) {
-      currentPage -= 1;
-      setPages({ currentPage, maxPages });
+  function decreasePage(e, num: number = 1) {
+    if (page - num >= 1) {
+      setPage(page - num);
     }
   }
 
@@ -142,63 +139,25 @@ function Leaderboard({
    * @desc Gets the page number of an item based on items per page
    * @param itemNumber - number of the item to get the page of
    */
-  function getPage(itemNumber: number) {
-    return Math.ceil(itemNumber / itemsPerPage);
-  }
-
-  /**
-   * @function addPage
-   * @desc Adjust the page of a user based on their current index in the array
-   * @param user - the user object
-   * @param index - the index in the array
-   */
-  function addPage(user: User, index: number) {
-    const {
-      email,
-      fName,
-      github,
-      id,
-      lName,
-      missions,
-      percentage,
-      phone,
-      planning,
-      rank,
-      review,
-      score,
-    } = user;
-    const page = getPage(index + 1);
-    return {
-      email,
-      fName,
-      github,
-      id,
-      lName,
-      missions,
-      page,
-      percentage,
-      phone,
-      planning,
-      rank,
-      review,
-      score,
-    };
+  function getPage(itemNumber: number): number {
+    return Math.floor(itemNumber / itemsPerPage) + 1;
   }
 
   return (
     <div style={{ margin: "25px 10px" }}>
       <h2>{I18n.get("leaderboard")}</h2>
       <div className="leaderboard-container" title="Leaderboard">
-        {ranking.some(({ score }) => score > 0) ? (
-          <Podium topUsers={topThree} removeNullScores={false} />
+        {rankedUsers.some(({ score }) => score > 0) ? (
+          <Podium topUsers={topUsers} removeNullScores={false} />
         ) : null}
         <div className="table-container" style={{ flexShrink: 1 }}>
-          <form onChange={filterRank} style={{ paddingBottom: "10px" }}>
+          <form style={{ paddingBottom: "10px" }}>
             <input
               className="form-control"
               type="search"
               name="search"
               placeholder="Filter by name..."
+              onChange={(e) => setFilterBy(e.target.value)}
             />
           </form>
           <Table
@@ -211,51 +170,60 @@ function Leaderboard({
             <tbody>
               <tr>
                 <td
+                  id="score"
                   className="rank-header text-center"
-                  onClick={sortUsersByScore}
+                  onClick={handleSortChange}
                 >
                   {I18n.get("rank")}
                 </td>
-                <td className="rank-header" onClick={sortUsersByScore}>
+                <td
+                  id="fName"
+                  className="rank-header"
+                  onClick={handleSortChange}
+                >
                   {I18n.get("name")}
                 </td>
                 <td
+                  id="score"
                   className="rank-header text-center"
-                  onClick={sortUsersByScore}
+                  onClick={handleSortChange}
                 >
                   {I18n.get("score")}
                 </td>
               </tr>
-              {ranking.map((user, i) =>
-                user.page === pages.currentPage ? (
-                  <tr
-                    className={currentUser.id === user.id ? "my-rank" : ""}
-                    key={user.id}
-                    data-testid="leaderboard-row"
-                  >
-                    <td className="data text-center">
-                      {i > 0 && user.rank == ranking[i - 1].rank
-                        ? "-"
-                        : user.rank}
-                    </td>
-                    <td
-                      onClick={() => history.push(`/profile/${user.id}`)}
-                      className="data2"
+              {rankedUsers
+                .sort(sortUsers)
+                .filter(filterUsers)
+                .map((user, i) =>
+                  getPage(i) === page ? (
+                    <tr
+                      className={currentUser.id === user.id ? "my-rank" : ""}
+                      key={user.id}
+                      data-testid="leaderboard-row"
                     >
-                      {`${user.fName} ${user.lName
-                        .substring(0, 1)
-                        .toUpperCase()}.`}
-                    </td>
-                    <td className="data text-center">{user.score} pts</td>
-                  </tr>
-                ) : null
-              )}
+                      <td className="data text-center">
+                        {i > 0 && user.rank == rankedUsers[i - 1].rank
+                          ? "-"
+                          : user.rank}
+                      </td>
+                      <td
+                        onClick={() => history.push(`/profile/${user.id}`)}
+                        className="data2"
+                      >
+                        {`${user.fName} ${user.lName
+                          .substring(0, 1)
+                          .toUpperCase()}.`}
+                      </td>
+                      <td className="data text-center">{user.score} pts</td>
+                    </tr>
+                  ) : null
+                )}
             </tbody>
           </Table>
-          {pages.maxPages > 1 ? (
+          {maxPages() > 0 ? (
             <PageNavigation
-              currentPage={pages.currentPage}
-              maxPages={pages.maxPages}
+              currentPage={page}
+              maxPages={maxPages()}
               increasePage={increasePage}
               decreasePage={decreasePage}
             />
@@ -272,10 +240,11 @@ type PodiumProps = {
 };
 function Podium({ topUsers, removeNullScores }: PodiumProps) {
   const sortedTopUsers: Array<User> = [];
+  let winners = [...topUsers];
   if (removeNullScores) {
-    topUsers = topUsers.filter(({ score }) => score > 0);
+    winners = winners.filter(({ score }) => score > 0);
   }
-  topUsers.forEach((user, i) => {
+  winners.forEach((user, i) => {
     i % 2 > 0 ? sortedTopUsers.push(user) : sortedTopUsers.unshift(user);
   });
 
@@ -288,7 +257,7 @@ function Podium({ topUsers, removeNullScores }: PodiumProps) {
             id={i}
             user={user}
             rank={user.rank || 1}
-            ranks={topUsers.length}
+            ranks={winners.length}
           />
         ))}
       </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,3 +11,26 @@ export type color =
 export type buttonType = "button" | "reset" | "submit" | undefined;
 
 export type buttonVariant = "text" | "contained" | "outlined" | undefined;
+
+export type PlanningField = {
+  name: string;
+  code: string;
+  content: string;
+};
+
+export interface User {
+  page: number;
+  rank?: number;
+  score: number;
+  id: number;
+  fName: string;
+  lName: string;
+  email: string;
+  github: string;
+  missions: Array<Object>;
+  percentage: number;
+  phone: string;
+  planning: Array<PlanningField>;
+  review: string;
+  profileImg?: File;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,7 +19,6 @@ export type PlanningField = {
 };
 
 export interface User {
-  page: number;
   rank?: number;
   score: number;
   id: number;


### PR DESCRIPTION
Pull-Request for `paretOS`

## Description
- Fixes direct manipulation of Sprint state. The Leaderboard component has been mutating (sorting) the teams array, which is why there are bugs in multiplayer arena where the daily achievement score points get assigned to the wrong user index. 
- Moved the User type to the /types directory index per discussion #126 
- Removed numerous logic errors and unnecessary array manipulation from my prior refactor back in October (😬)
- Eliminated redundant state management (anything that can be easily derived from another state should not be being managed via state) and simplified to three state variables: page, sortBy, and filterBy
- Added notes on possible tests to add to flesh out the unit testing for that component
- Moved the testing libraries from devDependencies to dependencies. (Since test is an available standalone script, this is where they should live.)
 
## Relates to
- #75 

## Reviewers
- @mikhael28  (merge duty)