### PR TITLE
Fix/loader button props passthrough

### DIFF
--- a/src/arena/SprintCreation.js
+++ b/src/arena/SprintCreation.js
@@ -344,14 +344,14 @@ function SprintCreation(props) {
         showNeighboringMonth
       />
       {/* <h3>Currently Selected Start Date: {startDate.toString()}</h3> */}
-        <LoaderButton
-          style={{ width: 350 }}
-          isLoading={loading}
-          loadingText={I18n.get("saving")}
-          text={I18n.get("create")}
-          disabled={!ready}
-          onClick={() => createSprint()}
-        />
+      <LoaderButton
+        style={{ width: 350 }}
+        isLoading={loading}
+        loadingText={I18n.get("saving")}
+        text={I18n.get("create")}
+        disabled={!ready}
+        onClick={() => createSprint()}
+      />
     </div>
   );
 }

--- a/src/arena/SprintCreation.js
+++ b/src/arena/SprintCreation.js
@@ -344,15 +344,14 @@ function SprintCreation(props) {
         showNeighboringMonth
       />
       {/* <h3>Currently Selected Start Date: {startDate.toString()}</h3> */}
-      <div onClick={() => createSprint()}>
         <LoaderButton
           style={{ width: 350 }}
           isLoading={loading}
           loadingText={I18n.get("saving")}
           text={I18n.get("create")}
           disabled={!ready}
+          onClick={() => createSprint()}
         />
-      </div>
     </div>
   );
 }

--- a/src/components/ArenaProofModal.js
+++ b/src/components/ArenaProofModal.js
@@ -109,7 +109,7 @@ export default function ArenaProofModal({
                     setFormData({ ...formData, key: "" });
                     handleClose();
                   }}
-                  bsSize="large"
+                  size="large"
                   text={I18n.get("submitProof")}
                   loadingText={I18n.get("creating")}
                   // ? Is there a reason this is commented?

--- a/src/components/LoaderButton.tsx
+++ b/src/components/LoaderButton.tsx
@@ -2,6 +2,23 @@ import { Button, Theme, ButtonProps } from "@mui/material";
 import { makeStyles, useTheme } from "@mui/styles";
 import Glyphicon from "react-bootstrap/lib/Glyphicon";
 
+// Custom sub-component to access theme and build/export useStyles
+// Prevents React from generating a new useStyles function each time the component is rendered
+const UseStyles = () => {
+  const theme: Theme = useTheme();
+
+  const useStyles = makeStyles({
+    root: {
+      "& .MuiButtonBase-root": {
+        marginTop: theme.spacing(1),
+        fontSize: 16,
+      },
+    },
+  });
+
+  return useStyles;
+};
+
 // Extend existing ButtonProps type to allow for our custom props
 interface CustomButtonProps extends ButtonProps {
   props: ButtonProps;
@@ -22,17 +39,7 @@ export default function LoaderButton({
   variant = "contained",
   ...props
 }: CustomButtonProps) {
-  const theme: Theme = useTheme();
-
-  const useStyles = makeStyles({
-    root: {
-      "& .MuiButtonBase-root": {
-        marginTop: theme.spacing(1),
-        fontSize: 16,
-      },
-    },
-  });
-  const classes = useStyles();
+  const classes = UseStyles()();
 
   return (
     <div className={classes.root}>

--- a/src/components/LoaderButton.tsx
+++ b/src/components/LoaderButton.tsx
@@ -1,26 +1,14 @@
-import { Button, Theme } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { Button, Theme, ButtonProps } from "@mui/material";
+import { makeStyles, useTheme } from "@mui/styles";
 import Glyphicon from "react-bootstrap/lib/Glyphicon";
-import { buttonType, buttonVariant, color } from "../types";
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    "& .MuiButtonBase-root": {
-      marginTop: theme.spacing(1),
-      fontSize: 16,
-    },
-  },
-}));
-
-interface ButtonProps {
+// Extend existing ButtonProps type to allow for our custom props
+interface CustomButtonProps extends ButtonProps {
+  props: ButtonProps;
   text: string;
   loadingText: string;
   isLoading: boolean;
   disabled: boolean;
-  className?: string;
-  type: buttonType;
-  color: color;
-  variant: buttonVariant;
 }
 
 export default function LoaderButton({
@@ -32,7 +20,18 @@ export default function LoaderButton({
   type = "button",
   color = "primary",
   variant = "contained",
-}: ButtonProps) {
+  ...props
+}: CustomButtonProps) {
+  const theme: Theme = useTheme();
+
+  const useStyles = makeStyles({
+    root: {
+      "& .MuiButtonBase-root": {
+        marginTop: theme.spacing(1),
+        fontSize: 16,
+      },
+    },
+  });
   const classes = useStyles();
 
   return (
@@ -43,6 +42,7 @@ export default function LoaderButton({
         type={type}
         color={color}
         variant={variant}
+        {...props}
       >
         {isLoading && <Glyphicon glyph="refresh" className="spinning" />}
         {!isLoading ? text : loadingText}

--- a/src/learn/BillingForm.js
+++ b/src/learn/BillingForm.js
@@ -114,7 +114,7 @@ class BillingForm extends Component {
         />
         <LoaderButton
           block
-          bsSize="large"
+          size="large"
           type="submit"
           text="Purchase"
           isLoading={loading}

--- a/src/learn/NewSubmitProofModal.js
+++ b/src/learn/NewSubmitProofModal.js
@@ -101,7 +101,7 @@ export default function SubmitProof({
                 });
                 setChanging(false);
               }}
-              bsSize="large"
+              size="large"
               text={I18n.get("submitProof")}
               loadingText={I18n.get("saving")}
               disabled={!validateForm()}

--- a/src/profile/ChangePassword.js
+++ b/src/profile/ChangePassword.js
@@ -83,7 +83,7 @@ const ChangePassword = (props) => {
         <LoaderButton
           block
           type="submit"
-          bsSize="large"
+          size="large"
           text={I18n.get("confirm")}
           loadingText={I18n.get("confirming")}
           disabled={!validateForm}

--- a/src/profile/CreateUser.js
+++ b/src/profile/CreateUser.js
@@ -231,7 +231,7 @@ export default class CreateUser extends Component {
           <LoaderButton
             align="center"
             block
-            bsSize="small"
+            size="small"
             type="submit"
             disabled={!this.validateForm()}
             onClick={() => this.setState({ showTermsOfService: true })}

--- a/src/profile/EditProfile.js
+++ b/src/profile/EditProfile.js
@@ -284,7 +284,7 @@ export default class EditProfile extends Component {
                 <LoaderButton
                   align="center"
                   block
-                  bsSize="small"
+                  size="small"
                   type="submit"
                   // disabled={!this.validateForm()}
                   onClick={this.updateBio}

--- a/src/profile/ResetPassword.js
+++ b/src/profile/ResetPassword.js
@@ -77,7 +77,7 @@ const ResetPassword = () => {
       <LoaderButton
         block
         type="submit"
-        bsSize="large"
+        size="large"
         loadingText={I18n.get("sending")}
         text={I18n.get("sendConfirmation")}
         isLoading={state.isSendingCode}
@@ -118,7 +118,7 @@ const ResetPassword = () => {
       <LoaderButton
         block
         type="submit"
-        bsSize="large"
+        size="large"
         text={I18n.get("confirm")}
         loadingText={I18n.get("confirming")}
         isLoading={state.isConfirming}

--- a/src/profile/Signup.js
+++ b/src/profile/Signup.js
@@ -83,7 +83,7 @@ const Signup = () => {
       </FormGroup>
       <LoaderButton
         block
-        bsSize="large"
+        size="large"
         disabled={!validateConfirmationForm()}
         type="submit"
         isLoading={isLoading}
@@ -131,7 +131,7 @@ const Signup = () => {
       </FormGroup>
       <LoaderButton
         block
-        bsSize="large"
+        size="large"
         disabled={!validateForm()}
         type="submit"
         isLoading={isLoading}

--- a/src/profile/TermsOfService.js
+++ b/src/profile/TermsOfService.js
@@ -19,7 +19,7 @@ export default function TermsOfService({
             <LoaderButton
               style={{ marginLeft: "auto" }}
               block
-              bsSize="small"
+              size="small"
               isLoading={isLoading}
               onClick={onClickAgree}
               text="I Agree"


### PR DESCRIPTION
Pull-Request for `paretOS`

## Description
Fixes props pass-through issue in LoaderButton component. Native props will now be automatically passed through to the MUI Button component in LoaderButton without the need to explicitly declare them in LoaderButtonProps. 

Fixes makeStyles so that it is able to access the theme using useTheme(), but remains outside the component (so that each instance of LoaderButton doesn't generate a new useStyles function.) 

Fixes a "bsSize" prop from LoaderButton instances that is no longer relevant now that the underlying button component has been transitioned to MUI.

## Relates to
Fixes #147 

## Reviewers
- @mikhael28  (merge duty)
