### PR TITLE
Fix left nav style bug

### DIFF
--- a/src/components/LeftNav.js
+++ b/src/components/LeftNav.js
@@ -355,7 +355,7 @@ function LeftNav(props) {
 
       <NavLink
         to="/context-builder"
-        style={subheadingStyle}
+        style={headingStyle}
         activeStyle={activeStyle}
         className="third-step"
         exact


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Pull-Request for `paretOS`

## Description
I just fired up the merged changes on main to take new photos for the Readme, and noticed that I had accidentally changed Library of Context to be styled as a sub-header. (It was a copy-paste error when I updated the style variable names.) 🤦  

## Relates to
- #153 

## Screenshots / other info
### With the fix
<img width="264" alt="Screen Shot 2022-03-31 at 7 18 04 PM" src="https://user-images.githubusercontent.com/84106309/161164956-1504dfbf-59f0-40f9-93a2-cf717fa23602.png">

### Without the fix
<img width="264" alt="Screen Shot 2022-03-31 at 7 18 19 PM" src="https://user-images.githubusercontent.com/84106309/161164960-8a29123d-2eee-4046-9dfd-a3dcf54d4248.png">

