### PR TITLE
Fix MUI style issues (unreadable form fields, black-on-black text) & logo color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -94,6 +94,14 @@ input[type="file"] {
   width: 100%;
 }
 
+/* temporary styles to override bootstrap conflicts with MUI */
+/* TODO: remove once bootstrap is completely gone */
+a.MuiButton-root:hover,
+a.MuiButton-root:focus {
+  color: rgb(222, 70, 101)!important
+}
+
+
 /* mobile/tablet styling */
 
 @media screen and (max-width: 768px) {

--- a/src/profile/Login.js
+++ b/src/profile/Login.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import Auth from "@aws-amplify/auth";
 import { I18n } from "@aws-amplify/core";
 import { Link } from "react-router-dom";
-import { Button, TextField } from "@mui/material";
+import { Button, TextField, useTheme } from "@mui/material";
 import { useForm } from "react-hook-form";
 import { makeStyles } from "@mui/styles";
 import logo from "../assets/Pareto_Lockup-01.png";
@@ -41,6 +41,7 @@ const Login = ({
   setLoading,
   userHasAuthenticated,
 }) => {
+  const theme = useTheme();
   const [isLoading, setIsLoading] = useState(false);
   const [disabled] = useState(false);
   const classes = useStyles();
@@ -75,15 +76,19 @@ const Login = ({
           alt="Pareto"
           height="45"
           width="180"
-          style={{ marginTop: 32 }}
+          style={{
+            marginTop: 32,
+            filter:
+              theme.palette.mode !== "dark" ? "" : "invert() brightness(150%)",
+          }}
         />
       </div>
 
       <form className={classes.root} onSubmit={handleSubmit(onSubmit)}>
-        <div>
+        <div style={{ backgroundColor: "#ccc" }}>
           <TextField
             id="email"
-            variant="standard"
+            variant="filled"
             size="medium"
             autoFocus
             label={I18n.get("email")}
@@ -98,10 +103,10 @@ const Login = ({
           <span className="error">{errors.email && errors.email.message}</span>
         </div>
         <br />
-        <div>
+        <div style={{ backgroundColor: "#ccc" }}>
           <TextField
             id="password"
-            variant="standard"
+            variant="filled"
             size="medium"
             type="password"
             label={I18n.get("password")}

--- a/src/profile/Signup.js
+++ b/src/profile/Signup.js
@@ -7,11 +7,13 @@ import FormControl from "react-bootstrap/lib/FormControl";
 import HelpBlock from "react-bootstrap/lib/HelpBlock";
 import Auth from "@aws-amplify/auth";
 import { I18n } from "@aws-amplify/core";
+import { useTheme } from "@mui/material";
 import logo from "../assets/Pareto_Lockup-01.png";
 import LoaderButton from "../components/LoaderButton";
 import { errorToast, successToast } from "../libs/toasts";
 
 const Signup = () => {
+  const theme = useTheme();
   const [email, setEmail] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [password, setPassword] = useState("");
@@ -68,7 +70,11 @@ const Signup = () => {
           alt="Pareto"
           height="45"
           width="180"
-          style={{ marginTop: 32 }}
+          style={{
+            marginTop: 32,
+            filter:
+              theme.palette.mode !== "dark" ? "" : "invert() brightness(150%)",
+          }}
         />
       </div>
       <FormGroup controlId="confirmationCode" bsSize="large">
@@ -101,7 +107,11 @@ const Signup = () => {
           alt="Pareto"
           height="45"
           width="180"
-          style={{ marginTop: 32 }}
+          style={{
+            marginTop: 32,
+            filter:
+              theme.palette.mode !== "dark" ? "" : "invert() brightness(150%)",
+          }}
         />
       </div>
       <FormGroup controlId="email" bsSize="large">


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Pull-Request for `paretOS`

## Description
- Fixes logo display to be inverted if site is in dark mode
- Adds a temporary inline styling fix for the Material UI input background color/text color mismatch bug 
- Adds a temporary override in index.css for a bootstrap style that conflicts with the MUI button. 

## Relates to
Temporarily fixes #164 with inline styling, but I'll also open a ticket seeking a longer-term solution. (The MUI background/text mismatch is going to be an issue across ALL forms they get converted.)

## Reviewers
- @mikhael28  (I'm going to merge immediately so new contributors can actually see the sign in form as they're trying to create their test accounts, but please review!)

### Screenshots 
<img width="864" alt="Screen Shot 2022-04-01 at 10 16 51 AM" src="https://user-images.githubusercontent.com/84106309/161281701-5b189672-85a1-4b4f-aceb-9f38b0070c81.png">
<img width="865" alt="Screen Shot 2022-04-01 at 10 16 41 AM" src="https://user-images.githubusercontent.com/84106309/161281706-c7b10252-7279-4356-949c-9426d35f01ae.png">

