### PR TITLE
Removing reconnecting websocket npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "react-spring": "8.0.27",
     "react-stripe-elements": "^1.6.0",
     "reactour": "^1.18.7",
-    "reconnecting-websocket": "^4.4.0",
     "redux": "^4.1.2",
     "socket.io-client": "^4.4.1",
     "source-map-explorer": "^2.5.2",

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,6 @@ import Image from "react-bootstrap/lib/Image";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import Tour from "reactour";
-import ReconnectingWebSocket from "reconnecting-websocket";
 import { GrLogout } from "react-icons/gr";
 import * as Sentry from "@sentry/react";
 import sortby from "lodash.sortby";
@@ -274,7 +273,7 @@ class App extends Component {
 
     let sprintString = sprintStrings.join("&");
 
-    let wsClient = new ReconnectingWebSocket(
+    let wsClient = new WebSocket(
       `wss://2los2emuze.execute-api.us-east-1.amazonaws.com/Prod?${sprintString}`
     );
 


### PR DESCRIPTION
As the description says, removing this package to avoid stupid amounts of connections being added to our Dynamo table.