### PR TITLE
Fix error toast notifications

### DIFF
--- a/src/components/LoaderButton.tsx
+++ b/src/components/LoaderButton.tsx
@@ -4,13 +4,16 @@ import Glyphicon from "react-bootstrap/lib/Glyphicon";
 
 // Custom sub-component to access theme and build/export useStyles
 // Prevents React from generating a new useStyles function each time the component is rendered
+// TODO: Remove conditional on spacing once toast notifications have been migrated to a library
+//       that can consume theme. See issue #171.
+
 const UseStyles = () => {
   const theme: Theme = useTheme();
 
   const useStyles = makeStyles({
     root: {
       "& .MuiButtonBase-root": {
-        marginTop: theme.spacing(1),
+        marginTop: theme?.spacing(1) || 8,
         fontSize: 16,
       },
     },

--- a/src/profile/EditProfile.js
+++ b/src/profile/EditProfile.js
@@ -282,15 +282,12 @@ export default class EditProfile extends Component {
                 </Button>
 
                 <LoaderButton
-                  align="center"
-                  block
-                  size="small"
                   type="submit"
                   // disabled={!this.validateForm()}
                   onClick={this.updateBio}
                   isLoading={this.state.isLoading}
                   text="Update Summary"
-                  loadingText="Creation"
+                  loadingText="Loading"
                 />
               </div>
             </>


### PR DESCRIPTION
Pull-Request for `paretOS`

## Description
Adds optional chaining & a conditional value to LoaderButton to circumvent the errorToast notification not being able to consume the theme. This should be revisited/removed once toast notifications are migrated to a better library - with most other libraries, this would not be an issue. (See #30 )

## Relates to
Fixes #171 

## Reviewers
- @mikhael28  (for visibility)

## Steps to reproduce (if describing bug fix)
See original bug report

### Screenshots / other info
<img width="990" alt="Screen Shot 2022-04-02 at 11 56 47 AM" src="https://user-images.githubusercontent.com/84106309/161391073-eab5ff68-4a7a-4b8f-8697-80559d7028d3.png">

