### PR TITLE
Login page backgroud and input text color changed as primary color

### DIFF
--- a/src/profile/Login.js
+++ b/src/profile/Login.js
@@ -13,16 +13,19 @@ const useStyles = makeStyles((theme) => ({
     paddingTop: theme.spacing(5),
     width: 300,
 
+    "& .css-36njyd-MuiInputBase-root-MuiFilledInput-root": {
+      backgroundColor: theme.palette.background.paper,
+    },
     "& .MuiTextField-root": {
       width: 300,
     },
     "& .MuiFormLabel-root": {
       fontSize: 16,
-      color: "#000",
+      color: theme.palette.primary.main,
     },
     "& .MuiInputBase-input": {
       fontSize: 16,
-      color: "#000",
+      color: theme.palette.primary.main,
     },
     "& .MuiButtonBase-root": {
       marginTop: theme.spacing(1),
@@ -85,7 +88,7 @@ const Login = ({
       </div>
 
       <form className={classes.root} onSubmit={handleSubmit(onSubmit)}>
-        <div style={{ backgroundColor: "#ccc" }}>
+        <div>
           <TextField
             id="email"
             variant="filled"
@@ -103,7 +106,7 @@ const Login = ({
           <span className="error">{errors.email && errors.email.message}</span>
         </div>
         <br />
-        <div style={{ backgroundColor: "#ccc" }}>
+        <div>
           <TextField
             id="password"
             variant="filled"

--- a/src/profile/Login.js
+++ b/src/profile/Login.js
@@ -25,7 +25,6 @@ const useStyles = makeStyles((theme) => ({
     },
     "& .MuiInputBase-input": {
       fontSize: 16,
-      color: theme.palette.primary.main,
     },
     "& .MuiButtonBase-root": {
       marginTop: theme.spacing(1),


### PR DESCRIPTION
Pull-Request for `paretOS`

## Description
- Updated Login.js file to changes the input text color and the label color
- removing the inline styles

## Relates to
- #166  or whichever ticket number the pr is addressing

## Reviewers
- @jayeclark 
- ...


### Screenshots / Login page
![image](https://user-images.githubusercontent.com/55104665/161610289-6f73740e-7b84-4d1a-8555-087a3c81fb22.png)
