### PR TITLE
Bootstrap migration: remove glyphicons in SprintCreation, LoaderButton, ExperienceModule

### DIFF
--- a/src/arena/SprintCreation.js
+++ b/src/arena/SprintCreation.js
@@ -7,7 +7,8 @@ import API from "@aws-amplify/api";
 import { I18n } from "@aws-amplify/core";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import Glyphicon from "react-bootstrap/lib/Glyphicon";
+import { FaTimes } from "react-icons/fa";
+import { useTheme } from "@mui/material";
 import Button from "react-bootstrap/lib/Button";
 import Calendar from "react-calendar";
 import cloneDeep from "lodash.clonedeep";
@@ -15,11 +16,14 @@ import { getActiveSprintData } from "../state/sprints";
 import { errorToast, successToast } from "../libs/toasts";
 import LoaderButton from "../components/LoaderButton";
 import "react-calendar/dist/Calendar.css";
+
 /**
  * This is the component where a user creates a new sprint, and selects which players are competing.
  * @TODO Re-integrate 'validateForm' functtion, to prevent people from selecting days in the past. Rethink what other purposes this could have.
  */
 function SprintCreation(props) {
+  const theme = useTheme();
+
   const [startDate, setStartDate] = useState(new Date());
   const [loading, setLoading] = useState(false);
   const [ready, setReady] = useState(false);
@@ -306,23 +310,30 @@ function SprintCreation(props) {
       </FormGroup>
       {chosenPlayers.map((chosen) => (
         <div key={chosen.id} className="block">
-          <p>
+          {/* TODO: evaluate if these inline styles should apply to all blocks & move to index.css */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginBottom: 0,
+            }}
+          >
             {chosen.fName} {chosen.lName}
             <Button
               onClick={() => removeChosenPlayer(chosen)}
               bsSize="large"
               style={{
-                float: "right",
-                marginTop: "-5px",
-                paddingTop: "10px",
-                paddingBottom: "10px",
-                backgroundColor: "white",
-                color: "red",
+                padding: "0px 5px",
+                margin: "3px 0px auto 0px",
+                backgroundColor: theme.palette.background.paper,
+                backgroundImage: "unset",
+                minWidth: "max-content",
               }}
             >
-              <Glyphicon glyph="glyphicon glyphicon-remove" />
+              <FaTimes />
             </Button>
-          </p>
+          </div>
         </div>
       ))}
       <Calendar

--- a/src/components/LoaderButton.tsx
+++ b/src/components/LoaderButton.tsx
@@ -1,6 +1,6 @@
 import { Button, Theme, ButtonProps } from "@mui/material";
 import { makeStyles, useTheme } from "@mui/styles";
-import Glyphicon from "react-bootstrap/lib/Glyphicon";
+import { MdAutorenew } from "react-icons/md";
 
 // Custom sub-component to access theme and build/export useStyles
 // Prevents React from generating a new useStyles function each time the component is rendered
@@ -54,7 +54,7 @@ export default function LoaderButton({
         variant={variant}
         {...props}
       >
-        {isLoading && <Glyphicon glyph="refresh" className="spinning" />}
+        {isLoading && <MdAutorenew className="spinning" />}
         {!isLoading ? text : loadingText}
       </Button>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -319,6 +319,7 @@ a.MuiButton-root:focus {
 .flex-apart {
   display: flex;
   justify-content: space-between;
+  align-items: center;
 }
 
 .flex-evenly {
@@ -385,7 +386,8 @@ a.MuiButton-root:focus {
 }
 
 .highlight-block {
-  padding: 8px;
+  font-size: 16px;
+  padding: 16px;
   border-radius: 3px;
   background: linear-gradient(70deg, var(--primary), var(--secondary));
   color: white;

--- a/src/index.css
+++ b/src/index.css
@@ -640,7 +640,7 @@ a.MuiButton-root:focus {
 
 /* button styles */
 
-.LoaderButton .spinning.glyphicon {
+.LoaderButton .spinning {
   margin-right: 7px;
   top: 2px;
   animation: spin 1s infinite linear;

--- a/src/learn/ExperienceModule.js
+++ b/src/learn/ExperienceModule.js
@@ -1,6 +1,8 @@
 import React, { Component } from "react";
 import ListGroup from "react-bootstrap/lib/ListGroup";
-import Glyphicon from "react-bootstrap/lib/Glyphicon";
+import { ImCheckmark } from "react-icons/im";
+import { FaSearch } from "react-icons/fa";
+import { MdCheckBoxOutlineBlank } from "react-icons/md";
 import Button from "react-bootstrap/lib/Button";
 import Image from "react-bootstrap/lib/Image";
 import API from "@aws-amplify/api";
@@ -299,14 +301,14 @@ class ExperienceModule extends Component {
               <div className="second-step-exp">
                 {mongoExperience[topic.priority].approved === true &&
                 mongoExperience[topic.priority].completed === true ? (
-                  <Glyphicon glyph="glyphicon glyphicon-ok" />
+                  <ImCheckmark />
                 ) : null}
                 {mongoExperience[topic.priority].completed === true &&
                 mongoExperience[topic.priority].approved === false ? (
-                  <Glyphicon glyph="glyphicon glyphicon-search" />
+                  <FaSearch />
                 ) : null}
                 {mongoExperience[topic.priority].completed === false ? (
-                  <Glyphicon glyph="glyphicon glyphicon-unchecked" />
+                  <MdCheckBoxOutlineBlank />
                 ) : null}
               </div>
             ) : null}


### PR DESCRIPTION
Pull-Request for `paretOS`

## Description
Replaces the `react-bootstrap` Glyphicon components in three files with icons from `react-icons` that have a very similar appearance. (Small bit of UI cleanup as well.)

## Relates to
Partially addresses #179 

## Reviewers
- @mikhael28 

### Screenshots / other info
<img width="693" alt="Screen Shot 2022-04-04 at 5 21 59 PM" src="https://user-images.githubusercontent.com/84106309/161646946-e478816b-7379-45e1-9dde-7272302f994c.png">
<img width="425" alt="Screen Shot 2022-04-04 at 7 10 34 PM" src="https://user-images.githubusercontent.com/84106309/161647172-a1f60887-612a-4db0-af1d-cfe609fcdd76.png">

<img width="1126" alt="Screen Shot 2022-04-04 at 7 08 43 PM" src="https://user-images.githubusercontent.com/84106309/161647000-06697113-5578-4d37-b421-532d7a8ae7d1.png">

