### PR TITLE
Refactor/convert App.js to use hooks

### DIFF
--- a/src/context/ContextBuilder.js
+++ b/src/context/ContextBuilder.js
@@ -98,13 +98,16 @@ function ContextBuilder(props) {
         </Tabs>
       </AppBar>
       <TabPanel value={value} index={0} className="tabPanelCont">
-        {renderTopicsList(props.sanitySchemas.technicalSchemas)}
+        {props.sanitySchemas &&
+          renderTopicsList(props.sanitySchemas.technicalSchemas)}
       </TabPanel>
       <TabPanel value={value} index={1} className="tabPanelCont">
-        {renderTopicsList(props.sanitySchemas.economicSchemas)}
+        {props.sanitySchemas &&
+          renderTopicsList(props.sanitySchemas?.economicSchemas)}
       </TabPanel>
       <TabPanel value={value} index={2} className="tabPanelCont">
-        {renderTopicsList(props.sanitySchemas.hubSchemas)}
+        {props.sanitySchemas &&
+          renderTopicsList(props.sanitySchemas?.hubSchemas)}
       </TabPanel>
 
       <Tour

--- a/src/libs/initialFetch.ts
+++ b/src/libs/initialFetch.ts
@@ -27,9 +27,9 @@ export const fetchUser = async (username: string) => {
 export const fetchStarterKitSanity = async () => {
   let result: ExperienceResult = {
     success: false,
-    sanityTraining: null,
-    sanityProduct: null,
-    sanityInterview: null,
+    sanityTraining: [],
+    sanityProduct: [],
+    sanityInterview: [],
   };
   try {
     let storedTrainingSanity = localStorage.getItem("trainingSanity");
@@ -145,9 +145,9 @@ export const fetchSanitySchemas = async () => {
   let result = {
     success: false,
     sanitySchemas: {
-      technicalSchemas: null,
-      economicSchemas: null,
-      hubSchemas: null,
+      technicalSchemas: [],
+      economicSchemas: [],
+      hubSchemas: [],
     },
   };
   try {

--- a/src/profile/CreateUser.js
+++ b/src/profile/CreateUser.js
@@ -60,7 +60,7 @@ const CreateUser = (props) => {
 
   const handleSubmit = async (event) => {
     event.preventDefault();
-    props.setLoading();
+    props.setLoading(true);
     // need to auto-generate cognito credentials for the email
     const productId = uuidv4();
     const apprenticeshipId = uuidv4();
@@ -130,7 +130,7 @@ const CreateUser = (props) => {
       props.history.push("/");
     } catch (e) {
       errorToast(e);
-      props.setCloseLoading();
+      props.setLoading(false);
     }
   };
 

--- a/src/profile/EditProfile.js
+++ b/src/profile/EditProfile.js
@@ -390,7 +390,7 @@ const EditProfile = () => {
         ) : null}
       </div>
       <br />
-      <LanguageSelector id={state.id} user={state.user} />
+      <LanguageSelector user={state.user} />
     </div>
   );
 };

--- a/src/profile/LanguageSelector.js
+++ b/src/profile/LanguageSelector.js
@@ -21,7 +21,7 @@ const LanguageSelector = (props) => {
   const handleChange = (e) => {
     updateLanguage({
       language: availableLanguages.find((x) => x.code === e.target.value),
-      id: props.id,
+      id: props.user.id,
       setLanguage: handleSetLanguage,
       setIsLoading: handleSetIsLoading,
     });

--- a/src/profile/Login.js
+++ b/src/profile/Login.js
@@ -37,12 +37,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const Login = ({
-  initialFetch,
-  setCloseLoading,
-  setLoading,
-  userHasAuthenticated,
-}) => {
+const Login = ({ initialFetch, setLoading, userHasAuthenticated }) => {
   const theme = useTheme();
   const [isLoading, setIsLoading] = useState(false);
   const [disabled] = useState(false);
@@ -54,7 +49,7 @@ const Login = ({
   } = useForm();
 
   const onSubmit = async (data) => {
-    setLoading();
+    setLoading(true);
 
     setIsLoading(true);
 
@@ -62,11 +57,11 @@ const Login = ({
       const user = await Auth.signIn(data.email, data.password);
       await initialFetch(user.username);
       userHasAuthenticated(true);
-      setCloseLoading();
+      setLoading(false);
     } catch (e) {
       alert(e.message);
       setIsLoading(false);
-      setCloseLoading();
+      setLoading(false);
     }
   };
 

--- a/src/profile/ResetPassword.js
+++ b/src/profile/ResetPassword.js
@@ -39,7 +39,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const ResetPassword = ({ setCloseLoading, setLoading }) => {
+const ResetPassword = ({ setLoading }) => {
   const classes = useStyles();
 
   const [isConfirming, setIsConfirming] = useState(false);
@@ -66,7 +66,7 @@ const ResetPassword = ({ setCloseLoading, setLoading }) => {
   let email1 = getValues("email");
 
   const handleSendCodeClick = async (data) => {
-    setLoading();
+    setLoading(true);
 
     setIsSendingCode(true);
 
@@ -74,27 +74,27 @@ const ResetPassword = ({ setCloseLoading, setLoading }) => {
       await Auth.forgotPassword(data.email);
 
       setCodeSent(true);
-      setCloseLoading();
+      setLoading(false);
     } catch (e) {
       alert(e.message);
       setIsSendingCode(false);
-      setCloseLoading();
+      setLoading(false);
     }
   };
 
   const handleConfirmClick = async (data) => {
-    setLoading();
+    setLoading(true);
 
     setIsConfirming(true);
 
     try {
       await Auth.forgotPasswordSubmit(email1, data.code, data.password);
       setConfirmed(true);
-      setCloseLoading();
+      setLoading(false);
     } catch (e) {
       alert(e.message);
       setIsConfirming(false);
-      setCloseLoading();
+      setLoading(false);
     }
   };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,3 +35,24 @@ export interface User {
   defaultLanguage?: string;
   instructor: boolean;
 }
+
+export interface Sprint {
+  id: string;
+  athleteId: string;
+  coachId: string;
+  startDate: Date;
+  endDate: Date;
+  started: boolean;
+  events: Array<object>;
+  studySessions: Array<object>;
+  type: string;
+  verified: boolean;
+  teams: Array<User>;
+  stake: {
+    title: string;
+    value: string;
+    conditions: Array<any>;
+  };
+  createdAt: Date;
+  updatedAt: Date;
+}


### PR DESCRIPTION
Pull-Request for `paretOS`

## Description
Initial refactor of App.js to use hooks. Major highlights:
- Reduces file length by nearly 200 lines of code (a lot of this has moved to libs, but we should be able to abstract that even further in a future PR.)
- Applies Promise.all to replace chained awaits where appropriate
- Moves several API queries to their own library for code clarity in App.js
- Refactors the queries so they return values instead of updating state (that way only one state update is needed after Promise.all, I was running into issues with some wonky behavior with batched state updates due to it being a functional component.
- Moves websocket to /libs and fixes a bug where disconnects were causing a new instance of websocket to be created and opened each time the socket disconnected (rather than just attempting to reconnect the original instance.)

Next PR, related to #5, will streamline state management (I had to partially address it in this PR just due to the different way that functional components handle state updates.) 

I think it would also be worthwhile discussing whether absolutely everything in the app needs to be loaded before the loading screen disappears. Currently it is loading data on the following areas of the app regardless of whether that's the area the user is actually looking at:
- experience (fetchStarterKitSanity and fetchStarterKitExperience
- context (fetchSanitySchemas)
- sprints (fetchSprints, connectSocketToSprint)
- relationships (fetchCoaches, fetchCoachingRoster)

It seems that only the relationships and ONE of the other three is typically needed based on where you are in the app. And if you are on the profile page or an individual sprint or context page, only relationships is needed at the app level. I think it might make sense to refactor App.js to split up the loading process - things necessary for time-to-first-content (based on the current router path) would need to load before the loading screen goes away, the other items would load in the background immediately after. 

This is a big one (and a big rework/simplification of the loading flow) so no rush.

## Relates to
- Fixes #188 
- Fixes #140

## Reviewers
- @mikhael28 
