### PR TITLE
Migrate react-bootstrap Button component in arena to MaterialUI Issue #177

### DIFF
--- a/src/arena/CreateSprintTemplate.js
+++ b/src/arena/CreateSprintTemplate.js
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from "react";
-import Button from "react-bootstrap/lib/Button";
 import FormGroup from "react-bootstrap/lib/FormGroup";
 import FormControl from "react-bootstrap/lib/FormControl";
 import ControlLabel from "react-bootstrap/lib/ControlLabel";
-import { useTheme } from "@mui/material";
+import { useTheme, Button } from "@mui/material";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { v4 as uuidv4 } from "uuid";
 import API from "@aws-amplify/api";
@@ -154,7 +153,9 @@ function CreateSprintTemplate(props) {
           onChange={(event) => setTitle(event.target.value)}
         />
       </FormGroup>
-      <Button onClick={createTemplate}>{I18n.get("create")} Sprint</Button>
+      <Button variant="gradient" onClick={createTemplate}>
+        {I18n.get("create")} Sprint
+      </Button>
       <div
         style={{
           display: "flex",

--- a/src/arena/Sprint.js
+++ b/src/arena/Sprint.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import { I18n } from "@aws-amplify/core";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-// import Button from "react-bootstrap/lib/Button";
 import Image from "react-bootstrap/lib/Image";
 import Tour from "reactour";
 import classNames from "classnames";

--- a/src/arena/Sprint.js
+++ b/src/arena/Sprint.js
@@ -5,17 +5,6 @@ import { connect } from "react-redux";
 import Image from "react-bootstrap/lib/Image";
 import Tour from "reactour";
 import classNames from "classnames";
-<<<<<<< refs/remotes/mikhael28/main
-import { AppBar, Tabs, Tab, Paper, useTheme } from "@mui/material";
-=======
-import {
-  Accordion,
-  AccordionItem,
-  AccordionItemHeading,
-  AccordionItemButton,
-  AccordionItemPanel,
-} from "react-accessible-accordion";
-import "react-accessible-accordion/dist/fancy-example.css";
 import {
   AppBar,
   Tabs,
@@ -25,7 +14,6 @@ import {
   Button,
   Chip,
 } from "@mui/material";
->>>>>>> change buttons to mui Button and Chip
 import Board from "../components/Board";
 import TabPanel from "../components/TabPanel.js";
 import StatsBlock from "../components/StatsBlock";
@@ -491,83 +479,46 @@ function Sprint(props) {
                     update you forgot.
                   </p>
 
-<<<<<<< refs/remotes/mikhael28/main
                   <div className="options-buttons">
                     {props.redux.sprint[activeSprintId].teams[
                       index
                     ].missions.map((mission, idx) => (
-                      <Button
+                      <Chip
+                        label={`Day ${idx + 1}`}
+                        variant="options"
+                        status={displayDay === idx ? "selected" : null}
                         onClick={() => {
                           setDisplayDay(idx);
                         }}
                         // eslint-disable-next-line react/no-array-index-key
                         key={idx}
-                      >
-                        Day {idx + 1}
-                      </Button>
+                      />
                     ))}
                   </div>
                   <div className="flex">
-                    {props.user.admin === true ? (
+                    {props.user.admin === false ? (
                       <div>
                         <p>Status: {status}</p>
-                        <div className="flex-apart">
-                          <Button onClick={() => setStatus("early")}>
-                            Set to Early
-                          </Button>
-                          <Button onClick={() => setStatus("active")}>
-                            Set to Active
-                          </Button>
-                          <Button onClick={() => setStatus("inactive")}>
-                            Set to Inactive
-                          </Button>
-                        </div>
-=======
-                      <div className="options-buttons">
-                        {props.redux.sprint[activeSprintId].teams[
-                          index
-                        ].missions.map((mission, idx) => (
+                        <div>
                           <Chip
-                            label={`Day ${idx + 1}`}
+                            label="Set to Early"
                             variant="options"
-                            status={displayDay === idx ? "selected" : null}
-                            onClick={() => {
-                              setDisplayDay(idx);
-                            }}
-                            // eslint-disable-next-line react/no-array-index-key
-                            key={idx}
+                            status={status === "early" ? "selected" : null}
+                            onClick={() => setStatus("early")}
                           />
-                        ))}
-                      </div>
-                      <div className="flex">
-                        {props.user.admin === true ? (
-                          <div>
-                            <p>Status: {status}</p>
-                            <div>
-                              <Chip
-                                label="Set to Early"
-                                variant="options"
-                                status={status === "early" ? "selected" : null}
-                                onClick={() => setStatus("early")}
-                              />
-                              <Chip
-                                label="Set to Active"
-                                variant="options"
-                                status={status === "active" ? "selected" : null}
-                                onClick={() => setStatus("active")}
-                              />
-                              <Chip
-                                label="Set to Inactive"
-                                variant="options"
-                                status={
-                                  status === "inactive" ? "selected" : null
-                                }
-                                onClick={() => setStatus("inactive")}
-                              />
-                            </div>
-                          </div>
-                        ) : null}
->>>>>>> change buttons to mui Button and Chip
+                          <Chip
+                            label="Set to Active"
+                            variant="options"
+                            status={status === "active" ? "selected" : null}
+                            onClick={() => setStatus("active")}
+                          />
+                          <Chip
+                            label="Set to Inactive"
+                            variant="options"
+                            status={status === "inactive" ? "selected" : null}
+                            onClick={() => setStatus("inactive")}
+                          />
+                        </div>
                       </div>
                     ) : null}
                   </div>

--- a/src/arena/Sprint.js
+++ b/src/arena/Sprint.js
@@ -541,7 +541,7 @@ function Sprint(props) {
                         ))}
                       </div>
                       <div className="flex">
-                        {props.user.admin === false ? (
+                        {props.user.admin === true ? (
                           <div>
                             <p>Status: {status}</p>
                             <div>

--- a/src/arena/Sprint.js
+++ b/src/arena/Sprint.js
@@ -2,11 +2,31 @@ import React, { useEffect, useState } from "react";
 import { I18n } from "@aws-amplify/core";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import Button from "react-bootstrap/lib/Button";
+// import Button from "react-bootstrap/lib/Button";
 import Image from "react-bootstrap/lib/Image";
 import Tour from "reactour";
 import classNames from "classnames";
+<<<<<<< refs/remotes/mikhael28/main
 import { AppBar, Tabs, Tab, Paper, useTheme } from "@mui/material";
+=======
+import {
+  Accordion,
+  AccordionItem,
+  AccordionItemHeading,
+  AccordionItemButton,
+  AccordionItemPanel,
+} from "react-accessible-accordion";
+import "react-accessible-accordion/dist/fancy-example.css";
+import {
+  AppBar,
+  Tabs,
+  Tab,
+  Paper,
+  useTheme,
+  Button,
+  Chip,
+} from "@mui/material";
+>>>>>>> change buttons to mui Button and Chip
 import Board from "../components/Board";
 import TabPanel from "../components/TabPanel.js";
 import StatsBlock from "../components/StatsBlock";
@@ -20,6 +40,7 @@ import {
   nextDay,
   updatePlanningForms,
 } from "../state/sprints";
+
 /**
  * This component handles the logic and UI of the Sprint functionality. It theoretically has multiplayer functionality, and keeps score between multiple competitors.
  * @TODO The indexing in multiplayer games seems to be off - investigate.
@@ -31,6 +52,7 @@ import {
  * @TODO Can the 'My Stats' header by updated to look any better? Can the stats tabs look a bit sharper? What does NBA look like?
  * @returns
  */
+
 function Sprint(props) {
   const theme = useTheme();
   const [status, setStatus] = useState("early");
@@ -304,6 +326,7 @@ function Sprint(props) {
                         className="planning-forms"
                       />
                       <Button
+                        variant="gradient"
                         onClick={() =>
                           savePlanning(
                             activeSprintId,
@@ -388,6 +411,7 @@ function Sprint(props) {
                           )}
                         </div>
                         <Button
+                          variant="gradient"
                           onClick={() => {
                             setShowProofModal(true);
                             setActiveIndex(i);
@@ -439,6 +463,7 @@ function Sprint(props) {
                         </div>
 
                         <Button
+                          variant="gradient"
                           onClick={() => {
                             setActiveIndex(id);
                             setActiveMission(mission);
@@ -467,6 +492,7 @@ function Sprint(props) {
                     update you forgot.
                   </p>
 
+<<<<<<< refs/remotes/mikhael28/main
                   <div className="options-buttons">
                     {props.redux.sprint[activeSprintId].teams[
                       index
@@ -497,6 +523,52 @@ function Sprint(props) {
                             Set to Inactive
                           </Button>
                         </div>
+=======
+                      <div className="options-buttons">
+                        {props.redux.sprint[activeSprintId].teams[
+                          index
+                        ].missions.map((mission, idx) => (
+                          <Chip
+                            label={`Day ${idx + 1}`}
+                            variant="options"
+                            status={displayDay === idx ? "selected" : null}
+                            onClick={() => {
+                              setDisplayDay(idx);
+                            }}
+                            // eslint-disable-next-line react/no-array-index-key
+                            key={idx}
+                          />
+                        ))}
+                      </div>
+                      <div className="flex">
+                        {props.user.admin === false ? (
+                          <div>
+                            <p>Status: {status}</p>
+                            <div>
+                              <Chip
+                                label="Set to Early"
+                                variant="options"
+                                status={status === "early" ? "selected" : null}
+                                onClick={() => setStatus("early")}
+                              />
+                              <Chip
+                                label="Set to Active"
+                                variant="options"
+                                status={status === "active" ? "selected" : null}
+                                onClick={() => setStatus("active")}
+                              />
+                              <Chip
+                                label="Set to Inactive"
+                                variant="options"
+                                status={
+                                  status === "inactive" ? "selected" : null
+                                }
+                                onClick={() => setStatus("inactive")}
+                              />
+                            </div>
+                          </div>
+                        ) : null}
+>>>>>>> change buttons to mui Button and Chip
                       </div>
                     ) : null}
                   </div>

--- a/src/arena/Sprint.js
+++ b/src/arena/Sprint.js
@@ -495,33 +495,30 @@ function Sprint(props) {
                       />
                     ))}
                   </div>
-                  <div className="flex">
-                    {props.user.admin === false ? (
-                      <div>
-                        <p>Status: {status}</p>
-                        <div>
-                          <Chip
-                            label="Set to Early"
-                            variant="options"
-                            status={status === "early" ? "selected" : null}
-                            onClick={() => setStatus("early")}
-                          />
-                          <Chip
-                            label="Set to Active"
-                            variant="options"
-                            status={status === "active" ? "selected" : null}
-                            onClick={() => setStatus("active")}
-                          />
-                          <Chip
-                            label="Set to Inactive"
-                            variant="options"
-                            status={status === "inactive" ? "selected" : null}
-                            onClick={() => setStatus("inactive")}
-                          />
-                        </div>
-                      </div>
-                    ) : null}
-                  </div>
+
+                  {props.user.admin === true ? (
+                    <>
+                      <p>Status: {status}</p>
+                      <Chip
+                        label="Set to Early"
+                        variant="options"
+                        status={status === "early" ? "selected" : null}
+                        onClick={() => setStatus("early")}
+                      />
+                      <Chip
+                        label="Set to Active"
+                        variant="options"
+                        status={status === "active" ? "selected" : null}
+                        onClick={() => setStatus("active")}
+                      />
+                      <Chip
+                        label="Set to Inactive"
+                        variant="options"
+                        status={status === "inactive" ? "selected" : null}
+                        onClick={() => setStatus("inactive")}
+                      />
+                    </>
+                  ) : null}
                 </div>
               </details>
             </>

--- a/src/arena/SprintCreation.js
+++ b/src/arena/SprintCreation.js
@@ -8,8 +8,7 @@ import { I18n } from "@aws-amplify/core";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { FaTimes } from "react-icons/fa";
-import { useTheme } from "@mui/material";
-import Button from "react-bootstrap/lib/Button";
+import { IconButton } from "@mui/material";
 import Calendar from "react-calendar";
 import cloneDeep from "lodash.clonedeep";
 import { getActiveSprintData } from "../state/sprints";
@@ -22,8 +21,6 @@ import "react-calendar/dist/Calendar.css";
  * @TODO Re-integrate 'validateForm' functtion, to prevent people from selecting days in the past. Rethink what other purposes this could have.
  */
 function SprintCreation(props) {
-  const theme = useTheme();
-
   const [startDate, setStartDate] = useState(new Date());
   const [loading, setLoading] = useState(false);
   const [ready, setReady] = useState(false);
@@ -320,19 +317,13 @@ function SprintCreation(props) {
             }}
           >
             {chosen.fName} {chosen.lName}
-            <Button
+            <IconButton
+              size="small"
+              style={{ padding: 7 }}
               onClick={() => removeChosenPlayer(chosen)}
-              bsSize="large"
-              style={{
-                padding: "0px 5px",
-                margin: "3px 0px auto 0px",
-                backgroundColor: theme.palette.background.paper,
-                backgroundImage: "unset",
-                minWidth: "max-content",
-              }}
             >
-              <FaTimes />
-            </Button>
+              <FaTimes style={{ transform: "scale(1.4)" }} />
+            </IconButton>
           </div>
         </div>
       ))}

--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -91,6 +91,55 @@ const theme = createTheme({
         },
       ],
     },
+    MuiButton: {
+      variants: [
+        {
+          props: { variant: "gradient" },
+          style: ({ theme }) => ({
+            background: "linear-gradient(70deg, #D95B35, #DE4665)",
+            "&:hover": { background: "linear-gradient(70deg,#db6e4d,#e0526e)" },
+            border: 0,
+            color: "#fff",
+            fontSize: "16px",
+            fontWeight: 600,
+            marginRight: "10px",
+            minWidth: "180px",
+            [theme.breakpoints.down(768)]: {
+              minWidth: "80px",
+            },
+            padding: "8px 16px",
+            transition: "background .3s",
+            lineHeight: 1.4,
+          }),
+        },
+      ],
+    },
+    MuiChip: {
+      variants: [
+        {
+          props: { variant: "options" },
+          style: ({ theme }) => ({
+            fontSize: "16px",
+            padding: "22px 8px",
+            marginRight: "8px",
+            marginBottom: "8px",
+            fontWeight: 600,
+            textTransform: "uppercase",
+            minWidth: "80px",
+            [theme.breakpoints.down(768)]: {
+              width: "100%",
+            },
+          }),
+        },
+        {
+          props: { variant: "options", status: "selected" },
+          style: {
+            background: "rgba(255, 255, 255, 0.44)",
+            "&:hover": { background: "rgba(255, 255, 255, 0.44)" },
+          },
+        },
+      ],
+    },
   },
 });
 


### PR DESCRIPTION
Pull-Request for `paretOS`

## Description
- Changed Button to material UI component in CreateSprintTemplate 
- Changed Button to IconButton in SprintCreation
- Changed Button to material UI Button and Chip in Sprint
- Added Button gradient variant and Chip variant to `libs/theme`

## Relates to
- [Refactor:  Migrate react-bootstrap Button component to MaterialUI](https://github.com/mikhael28/paretOS/issues/177)

## Reviewers
- @jayeclark 
- @mikhael28 

### Screenshots / other info
<img width="50%" alt="Screen Shot 2022-04-13 at 5 38 46 PM" src="https://user-images.githubusercontent.com/64330181/163292718-ae7bfe1a-47bd-402f-9393-c9411c0539d5.png">

<img width="50%" alt="Screen Shot 2022-04-13 at 5 53 22 PM" src="https://user-images.githubusercontent.com/64330181/163293022-4b7695f4-68c6-40f7-a639-0493a1f15e42.png">

<img width="50%" alt="Screen Shot 2022-04-13 at 5 41 35 PM" src="https://user-images.githubusercontent.com/64330181/163292736-e886e13a-cee1-4f4d-beab-bb46c0cbc70c.png">

<img width="50%" alt="Screen Shot 2022-04-13 at 2 01 53 PM" src="https://user-images.githubusercontent.com/64330181/163292748-637c2d7b-a03f-4ea7-bb7d-97b02afd7056.png">
<img width="50%" alt="Screen Shot 2022-04-13 at 5 42 22 PM" src="https://user-images.githubusercontent.com/64330181/163292765-99e24895-5440-41fa-a7f5-2eabe1f533c1.png">

