### PR TITLE
Fix S3 proof uploading failure

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import { StrictMode } from "react";
 import ReactDOM from "react-dom";
-import Amplify from "@aws-amplify/core";
-import API from "@aws-amplify/api";
-import Storage from "@aws-amplify/storage";
+import { Amplify } from "@aws-amplify/core";
+import { API } from "@aws-amplify/api";
+import { Storage } from "@aws-amplify/storage";
 import { BrowserRouter as Router } from "react-router-dom";
 import { Provider } from "react-redux";
 import { createStore } from "redux";
@@ -55,7 +55,8 @@ API.configure({
 
 Storage.configure({
   AWSS3: {
-    bucket: process.env.REACT_APP_PHOTO_BUCKET,
+    bucket: process.env.REACT_APP_PROOF_BUCKET,
+    region: process.env.REACT_APP_UTIL_REGION,
   },
 });
 

--- a/src/libs/s3.js
+++ b/src/libs/s3.js
@@ -1,9 +1,7 @@
-import Storage from "@aws-amplify/storage";
+import { Storage } from "@aws-amplify/storage";
 
 export default async function uploadToS3(fileName, file, fileType) {
-  const pictureKey = await Storage.put(`${fileName}.${fileType}`, file, {
-    bucket: process.env.REACT_APP_PROOF_BUCKET,
-  });
+  const pictureKey = await Storage.put(`${fileName}.${fileType}`, file);
 
   return pictureKey;
 }


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Pull-Request for `paretOS`

## Description
Updates AWSAmplify configuration to fix bucket name and add region, fixes deprecated imports & syntax. (I also fixed the bucket policy on the back end which was the majority of the work here.) 

Proof of daily achievements now uploads to S3 as intended and is available for users to download! Currently it just downloads rather than being displayed, so, I may open a ticket for that refinement. 

## Relates to
- Fixes #140 

## Reviewers
- @mikhael28 

### Screenshots / other info
Screenshot showing proof link and downloaded proof.
<img width="1355" alt="Screen Shot 2022-04-20 at 12 26 16 PM" src="https://user-images.githubusercontent.com/84106309/164278205-8a09b270-88d9-4e20-a23c-d47a12a604e6.png">

