### PR TITLE
Convert to RestAPI and fix default imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.3",
   "private": true,
   "dependencies": {
-    "@aws-amplify/api": "^4.0.33",
+    "@aws-amplify/api-rest": "^2.0.38",
     "@aws-amplify/auth": "^4.4.2",
     "@aws-amplify/core": "^4.4.0",
     "@aws-amplify/storage": "^4.4.16",

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
-import Auth from "@aws-amplify/auth";
+import { Auth } from "@aws-amplify/auth";
 import { I18n } from "@aws-amplify/core";
-import API from "@aws-amplify/api";
+import { RestAPI } from "@aws-amplify/api-rest";
 import { withRouter } from "react-router-dom";
 import Image from "react-bootstrap/lib/Image";
 import { bindActionCreators } from "redux";
@@ -229,7 +229,7 @@ class App extends Component {
   connectSocketToSprint = async () => {
     let result = { success: false, sprints: null };
     try {
-      const sprints = await API.get(
+      const sprints = await RestAPI.get(
         "pareto",
         `/sprints/mentee/${this.state.user.id}`
       );
@@ -289,7 +289,10 @@ class App extends Component {
 
   fetchMenteeSprints = async (userId) => {
     try {
-      let menteeSprints = await API.get("pareto", `/sprints/mentee/${userId}`);
+      let menteeSprints = await RestAPI.get(
+        "pareto",
+        `/sprints/mentee/${userId}`
+      );
       this.setState({ sprints: menteeSprints });
     } catch (e) {
       errorToast(e);

--- a/src/arena/CreateSprintTemplate.js
+++ b/src/arena/CreateSprintTemplate.js
@@ -5,7 +5,7 @@ import ControlLabel from "react-bootstrap/lib/ControlLabel";
 import { useTheme, Button } from "@mui/material";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { v4 as uuidv4 } from "uuid";
-import API from "@aws-amplify/api";
+import { RestAPI } from "@aws-amplify/api-rest";
 import { I18n } from "@aws-amplify/core";
 import sanity from "../libs/sanity";
 import { errorToast } from "../libs/toasts";
@@ -105,7 +105,7 @@ function CreateSprintTemplate(props) {
       createdAt: Date.now(),
     };
     try {
-      await API.post("pareto", `/templates`, { body });
+      await RestAPI.post("pareto", `/templates`, { body });
       props.history.push("/");
     } catch (e) {
       errorToast(e, props.user);

--- a/src/arena/SprintCreation.js
+++ b/src/arena/SprintCreation.js
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 import FormGroup from "react-bootstrap/lib/FormGroup";
 import ControlLabel from "react-bootstrap/lib/ControlLabel";
 import FormControl from "react-bootstrap/lib/FormControl";
-import API from "@aws-amplify/api";
+import { RestAPI } from "@aws-amplify/api-rest";
 import { I18n } from "@aws-amplify/core";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
@@ -35,8 +35,8 @@ function SprintCreation(props) {
 
   async function getConfiguration() {
     setLoading(true);
-    let options = await API.get("pareto", "/templates");
-    let userOptions = await API.get("pareto", "/users");
+    let options = await RestAPI.get("pareto", "/templates");
+    let userOptions = await RestAPI.get("pareto", "/users");
     setMissions(options);
     setPlayers(userOptions.filter((e) => e.id !== props.profile.id));
     setLoading(false);
@@ -183,7 +183,7 @@ function SprintCreation(props) {
       teams: databasedTeams,
     };
     try {
-      await API.post("pareto", "/sprints", { body });
+      await RestAPI.post("pareto", "/sprints", { body });
       await props.connectSocket();
       successToast("Sprint created successfully.");
       props.history.push("/");

--- a/src/arena/Sprints.js
+++ b/src/arena/Sprints.js
@@ -2,7 +2,7 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { I18n } from "@aws-amplify/core";
 import classNames from "classnames";
-import API from "@aws-amplify/api";
+import { RestAPI } from "@aws-amplify/api-rest";
 import { getActiveSprintData } from "../state/sprints";
 
 /**
@@ -73,7 +73,7 @@ function Sprints(props) {
                     {props.user.admin === true ? (
                       <button
                         onClick={async () => {
-                          await API.del("pareto", `/sprints/${sprint.id}`);
+                          await RestAPI.del("pareto", `/sprints/${sprint.id}`);
                           await props.fetchMenteeSprints(props.user.id);
                         }}
                       >

--- a/src/context/SuggestionModal.js
+++ b/src/context/SuggestionModal.js
@@ -4,7 +4,7 @@ import FormGroup from "react-bootstrap/lib/FormGroup";
 import ControlLabel from "react-bootstrap/lib/ControlLabel";
 import FormControl from "react-bootstrap/lib/FormControl";
 import Button from "react-bootstrap/lib/Button";
-import { API } from "@aws-amplify/api";
+import { RestAPI } from "@aws-amplify/api-rest";
 import LoaderButton from "../components/LoaderButton";
 import { errorToast, successToast } from "../libs/toasts";
 import { generateEmail } from "../libs/errorEmail";
@@ -72,7 +72,7 @@ export default function SuggestionModal({ schema, user, handleClose }) {
         .then((response) => response.json())
         .catch((error) => console.error(error));
 
-      await API.post("util", "/email", {
+      await RestAPI.post("util", "/email", {
         body: {
           recipient: "michael@pareto.education",
           sender: "michael@pareto.education",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { StrictMode } from "react";
 import ReactDOM from "react-dom";
 import { Amplify } from "@aws-amplify/core";
-import { API } from "@aws-amplify/api";
+import { RestAPI } from "@aws-amplify/api-rest";
 import { Storage } from "@aws-amplify/storage";
 import { BrowserRouter as Router } from "react-router-dom";
 import { Provider } from "react-redux";
@@ -38,7 +38,7 @@ if (process.env.NODE_ENV === "production") {
 const store = createStore(reducer);
 
 Amplify.configure(awsmobile);
-API.configure({
+RestAPI.configure({
   endpoints: [
     {
       name: "pareto",

--- a/src/learn/ExperienceModule.js
+++ b/src/learn/ExperienceModule.js
@@ -4,7 +4,7 @@ import { FaSearch } from "react-icons/fa";
 import { MdCheckBoxOutlineBlank } from "react-icons/md";
 import Button from "react-bootstrap/lib/Button";
 import Image from "react-bootstrap/lib/Image";
-import API from "@aws-amplify/api";
+import { RestAPI } from "@aws-amplify/api-rest";
 import BlockContent from "@sanity/block-content-to-react";
 import { Slide, Dialog } from "@mui/material";
 import { I18n } from "@aws-amplify/core";
@@ -110,7 +110,7 @@ class ExperienceModule extends Component {
     let path = pathArray[2];
     let expType;
 
-    let comparisonData = await API.get("pareto", `/experience/${path}`);
+    let comparisonData = await RestAPI.get("pareto", `/experience/${path}`);
 
     if (comparisonData[0].type === "Apprenticeship") {
       expType = this.props.sanityTraining;
@@ -128,7 +128,7 @@ class ExperienceModule extends Component {
       isLoading: false,
     });
 
-    let athleteProfile = await API.get(
+    let athleteProfile = await RestAPI.get(
       "pareto",
       `/users/${comparisonData[0].memberId}`
     );
@@ -153,7 +153,7 @@ class ExperienceModule extends Component {
         `Pareto Achievement for Review!`,
         `Your athlete ${this.state.user.fName} ${this.state.user.lName} has submitted the work submitted for the milestone called '${this.state.activeExperience.title}. There is ${milestoneXP} XP at stake - you are doing a great job providing mentorship and guidance!'`
       );
-      const updatedExperienceModule = await API.put(
+      const updatedExperienceModule = await RestAPI.put(
         "pareto",
         `/experience/${this.state.experienceId}`,
         { body }
@@ -162,7 +162,7 @@ class ExperienceModule extends Component {
         showSubmitModal: false,
         mongoExperience: updatedExperienceModule,
       });
-      await API.post("util", "/email", {
+      await RestAPI.post("util", "/email", {
         body: {
           recipient: this.props.user.email,
           sender: "michael@fsa.community",
@@ -195,7 +195,7 @@ class ExperienceModule extends Component {
         `Pareto Achievement Sent Back for Review!`,
         `Your coach has requested that the work submitted for the milestone called '${this.state.activeExperience.title}' be revised according to their feedback. Please log-in to https://arena.pareto.education for their details. There is ${milestoneXP} XP at stake - you are doing a great job learning and growing every day!'`
       );
-      const updatedExperienceModule = await API.put(
+      const updatedExperienceModule = await RestAPI.put(
         "pareto",
         `/experience/${this.state.experienceId}`,
         { body }
@@ -204,7 +204,7 @@ class ExperienceModule extends Component {
         showSubmitModal: false,
         mongoExperience: updatedExperienceModule,
       });
-      await API.post("util", "/email", {
+      await RestAPI.post("util", "/email", {
         body: {
           recipient: this.state.user.email,
           sender: "michael@fsa.community",
@@ -240,7 +240,7 @@ class ExperienceModule extends Component {
         `Congratulations! Your coach has approved the work submitted for the milestone called '${this.state.activeExperience.title}'. You have earned ${milestoneXP} XP - you are doing a great job!'`
       );
 
-      const updatedExperienceModule = await API.put(
+      const updatedExperienceModule = await RestAPI.put(
         "pareto",
         `/experience/${this.state.experienceId}`,
         { body }
@@ -250,7 +250,7 @@ class ExperienceModule extends Component {
         mongoExperience: updatedExperienceModule,
         openReviewModal: false,
       });
-      await API.post("util", "/email", {
+      await RestAPI.post("util", "/email", {
         body: {
           recipient: "mikhael@hey.com",
           sender: "michael@fsa.community",

--- a/src/learn/LearnDashboard.js
+++ b/src/learn/LearnDashboard.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { init } from "pell";
-import API from "@aws-amplify/api";
+import { RestAPI } from "@aws-amplify/api-rest";
 import classNames from "classnames";
 import FormGroup from "react-bootstrap/lib/FormGroup";
 import { Slide, Dialog } from "@mui/material";
@@ -43,7 +43,7 @@ function LearnDashboard(props) {
 
   async function editNote() {
     try {
-      await API.put("pareto", `/users/${props.user.id}`, {
+      await RestAPI.put("pareto", `/users/${props.user.id}`, {
         body: {
           notes: [html],
         },

--- a/src/learn/Order.js
+++ b/src/learn/Order.js
@@ -1,5 +1,5 @@
 import { Component } from "react";
-import API from "@aws-amplify/api";
+import { RestAPI } from "@aws-amplify/api-rest";
 import { Elements, StripeProvider } from "react-stripe-elements";
 import { Button } from "@mui/material";
 import BillingForm from "./BillingForm";
@@ -27,7 +27,7 @@ export default class Order extends Component {
     } else {
       route = "/billing";
     }
-    return API.post("util", route, {
+    return RestAPI.post("util", route, {
       body: details,
     });
   }
@@ -37,9 +37,13 @@ export default class Order extends Component {
       learningPurchase: true,
     };
 
-    let updatedUser = await API.put("pareto", `/users/${this.props.user.id}`, {
-      body,
-    });
+    let updatedUser = await RestAPI.put(
+      "pareto",
+      `/users/${this.props.user.id}`,
+      {
+        body,
+      }
+    );
     console.log(updatedUser);
 
     let apprenticeParams = {

--- a/src/libs/createExperience.js
+++ b/src/libs/createExperience.js
@@ -1,4 +1,4 @@
-import API from "@aws-amplify/api";
+import { RestAPI } from "@aws-amplify/api-rest";
 
 /**
  * Reusable function to create experience items.
@@ -46,7 +46,7 @@ export async function createExperience(params) {
     _15: achievement,
   };
   try {
-    const response = await API.post("pareto", "/experience", { body });
+    const response = await RestAPI.post("pareto", "/experience", { body });
     return response;
   } catch (e) {
     console.log("Error creating EXP: ", e);

--- a/src/libs/errorEmail.js
+++ b/src/libs/errorEmail.js
@@ -1,4 +1,4 @@
-import API from "@aws-amplify/api";
+import { RestAPI } from "@aws-amplify/api-rest";
 
 /**
  * A function to generate an email.
@@ -527,5 +527,5 @@ export function generateErrorEmail(
     htmlBody: email,
     textBody: "Hello",
   };
-  return API.post("util", "/email", { body });
+  return RestAPI.post("util", "/email", { body });
 }

--- a/src/libs/initialFetch.ts
+++ b/src/libs/initialFetch.ts
@@ -1,4 +1,4 @@
-import API from "@aws-amplify/api/";
+import { RestAPI } from "@aws-amplify/api-rest";
 import sortby from "lodash.sortby";
 import sanity from "./sanity";
 import { errorToast } from "./toasts";
@@ -6,7 +6,7 @@ import { errorToast } from "./toasts";
 export const fetchUser = async (username) => {
   let user = {};
   try {
-    user = await API.get("pareto", `/users/${username}`, {});
+    user = await RestAPI.get("pareto", `/users/${username}`, {});
   } catch (e) {
     console.error(e);
   }
@@ -65,7 +65,7 @@ export const fetchStarterKitExperience = async (id) => {
     experiences: null,
   };
   try {
-    let experiences = await API.get("pareto", `/experience/user/${id}`, {});
+    let experiences = await RestAPI.get("pareto", `/experience/user/${id}`, {});
     let product;
     let apprenticeship;
     let interviewing;
@@ -93,7 +93,11 @@ export const fetchStarterKitExperience = async (id) => {
 export const fetchCoachingRoster = async (id) => {
   const result = { success: false, athletes: null };
   try {
-    let athletes = await API.get("pareto", `/relationship/mentor/${id}`, {});
+    let athletes = await RestAPI.get(
+      "pareto",
+      `/relationship/mentor/${id}`,
+      {}
+    );
     result.success = true;
     result.athletes = athletes;
   } catch (e) {
@@ -107,7 +111,11 @@ export const fetchCoaches = async (id) => {
   try {
     let existingCoaches = localStorage.getItem("coaches");
     if (existingCoaches === null) {
-      let coaches = await API.get("pareto", `/relationship/mentee/${id}`, {});
+      let coaches = await RestAPI.get(
+        "pareto",
+        `/relationship/mentee/${id}`,
+        {}
+      );
       result.success = true;
       result.coaches = coaches;
       localStorage.setItem("coaches", JSON.stringify(coaches));

--- a/src/libs/languages.js
+++ b/src/libs/languages.js
@@ -1,4 +1,4 @@
-import API from "@aws-amplify/api";
+import { RestAPI } from "@aws-amplify/api-rest";
 import { I18n } from "@aws-amplify/core";
 
 export const availableLanguages = [
@@ -53,7 +53,7 @@ export async function updateLanguage({
   try {
     I18n.setLanguage(language.code);
     setLanguage(language);
-    await API.put("pareto", `/users/${id}`, {
+    await RestAPI.put("pareto", `/users/${id}`, {
       body,
     });
   } catch (e) {

--- a/src/mentorship/MenteeProfile.js
+++ b/src/mentorship/MenteeProfile.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import API from "@aws-amplify/api";
+import { RestAPI } from "@aws-amplify/api-rest";
 import { I18n } from "@aws-amplify/core";
 import Image from "react-bootstrap/lib/Image";
 import { Link } from "react-router-dom";
@@ -31,7 +31,7 @@ function Profile() {
   }, [window.location.pathname]);
 
   const getUser = async (id) => {
-    let user = await API.get("pareto", `/users/${id}`);
+    let user = await RestAPI.get("pareto", `/users/${id}`);
     if (user.length > 0) {
       setProfile(user[0]);
     }
@@ -41,7 +41,7 @@ function Profile() {
 
   const getExperienceByUser = async (id) => {
     try {
-      let experiences = await API.get("pareto", `/experience/user/${id}`);
+      let experiences = await RestAPI.get("pareto", `/experience/user/${id}`);
       setExperiences(experiences);
     } catch (e) {
       errorToast(e);
@@ -50,7 +50,7 @@ function Profile() {
 
   const getSprintsByUser = async (id) => {
     try {
-      let sprints = await API.get("pareto", `/sprints/mentee/${id}`);
+      let sprints = await RestAPI.get("pareto", `/sprints/mentee/${id}`);
       setSprints(sprints);
       setLoading(false);
     } catch (e) {

--- a/src/profile/ChangePassword.js
+++ b/src/profile/ChangePassword.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import Auth from "@aws-amplify/auth";
+import { Auth } from "@aws-amplify/auth";
 import { I18n } from "@aws-amplify/core";
 import FormGroup from "react-bootstrap/lib/FormGroup";
 import ControlLabel from "react-bootstrap/lib/ControlLabel";

--- a/src/profile/CreateUser.js
+++ b/src/profile/CreateUser.js
@@ -1,5 +1,5 @@
-import Auth from "@aws-amplify/auth";
-import API from "@aws-amplify/api";
+import { Auth } from "@aws-amplify/auth";
+import { RestAPI } from "@aws-amplify/api-rest";
 import { v4 as uuidv4 } from "uuid";
 import { useState } from "react";
 import FormGroup from "react-bootstrap/lib/FormGroup";
@@ -47,7 +47,7 @@ const CreateUser = (props) => {
       textBody: `Welcome to the ParetOS - an experimental, high-level operating system that lives in the browser to maximize your human performance and growth. You can login at https://paret0.com with the email ${email} and the password you created.`,
     };
     try {
-      await API.post("util", "/email", { body });
+      await RestAPI.post("util", "/email", { body });
     } catch (e) {
       console.log("Email send error: ", e);
     }
@@ -81,7 +81,7 @@ const CreateUser = (props) => {
       const session = await Auth.currentSession();
       uuid = session.idToken.payload.sub;
       tempEmail = session.idToken.payload.email;
-      await API.post("pareto", "/users", {
+      await RestAPI.post("pareto", "/users", {
         body: {
           id: uuid,
           type: state.type,

--- a/src/profile/EditProfile.js
+++ b/src/profile/EditProfile.js
@@ -7,9 +7,9 @@ import Button from "react-bootstrap/lib/Button";
 import { BsPencil, BsPlusLg } from "react-icons/bs";
 // import Image from "react-bootstrap/lib/Image";
 import { v4 as uuidv4 } from "uuid";
-import API from "@aws-amplify/api";
+import { RestAPI } from "@aws-amplify/api-rest";
 import { I18n } from "@aws-amplify/core";
-import Storage from "@aws-amplify/storage";
+import { Storage } from "@aws-amplify/storage";
 import { errorToast } from "../libs/toasts";
 import LoaderButton from "../components/LoaderButton";
 // import question from "../assets/help.png";
@@ -54,7 +54,7 @@ const EditProfile = () => {
     let userId;
     userId = path[path.length - 1];
     // what we did above, was the get the user id from the navigation bar
-    const response = await API.get("pareto", `/users/${userId}`);
+    const response = await RestAPI.get("pareto", `/users/${userId}`);
     // here we are populating our initial state. In the future, we will likely just pass stuff in via props, instead of running a fresh network request. That was a legacy decision, don't worry about it @antonio-b
     setState((prevState) => ({
       ...prevState,
@@ -84,7 +84,7 @@ const EditProfile = () => {
       summary: state.summary,
     };
     try {
-      const response = await API.put("pareto", `/users/${state.id}`, {
+      const response = await RestAPI.put("pareto", `/users/${state.id}`, {
         body,
       });
       setState((prevState) => ({
@@ -105,7 +105,7 @@ const EditProfile = () => {
       lName: state.lName,
     };
     try {
-      const newName = await API.put("pareto", `/users/${state.id}`, {
+      const newName = await RestAPI.put("pareto", `/users/${state.id}`, {
         body,
       });
       setState((prevState) => ({
@@ -136,7 +136,7 @@ const EditProfile = () => {
       projects: projects,
     };
     try {
-      const response = await API.put("pareto", `/users/${state.user.id}`, {
+      const response = await RestAPI.put("pareto", `/users/${state.user.id}`, {
         body,
       });
       setState((prevState) => ({
@@ -168,11 +168,15 @@ const EditProfile = () => {
         }
       );
       console.log("Key: ", pictureKey);
-      let updatedProfile = await API.put("pareto", `/users/${state.user.id}`, {
-        body: {
-          picture: `https://${process.env.REACT_APP_PHOTO_BUCKET}.s3.amazonaws.com/public/${pictureKey.key}`,
-        },
-      });
+      let updatedProfile = await RestAPI.put(
+        "pareto",
+        `/users/${state.user.id}`,
+        {
+          body: {
+            picture: `https://${process.env.REACT_APP_PHOTO_BUCKET}.s3.amazonaws.com/public/${pictureKey.key}`,
+          },
+        }
+      );
       console.log(updatedProfile);
       setState((prevState) => ({
         ...prevState,

--- a/src/profile/Login.js
+++ b/src/profile/Login.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import Auth from "@aws-amplify/auth";
+import { Auth } from "@aws-amplify/auth";
 import { I18n } from "@aws-amplify/core";
 import { Link } from "react-router-dom";
 import { Button, TextField, useTheme } from "@mui/material";

--- a/src/profile/ResetPassword.js
+++ b/src/profile/ResetPassword.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import Auth from "@aws-amplify/auth";
+import { Auth } from "@aws-amplify/auth";
 import { I18n } from "@aws-amplify/core";
 import { Link } from "react-router-dom";
 import FormGroup from "react-bootstrap/lib/FormGroup";

--- a/src/profile/Signup.js
+++ b/src/profile/Signup.js
@@ -5,7 +5,7 @@ import FormGroup from "react-bootstrap/lib/FormGroup";
 import ControlLabel from "react-bootstrap/lib/ControlLabel";
 import FormControl from "react-bootstrap/lib/FormControl";
 import HelpBlock from "react-bootstrap/lib/HelpBlock";
-import Auth from "@aws-amplify/auth";
+import { Auth } from "@aws-amplify/auth";
 import { I18n } from "@aws-amplify/core";
 import { useTheme } from "@mui/material";
 import logo from "../assets/Pareto_Lockup-01.png";

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,37 +18,15 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@aws-amplify/api-graphql@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/api-graphql/-/api-graphql-2.3.1.tgz#4dcfd681b89d3006f9fcd7b5659342c1f901308f"
-  integrity sha512-O2GtAhfi2uV85rUAl/CGSdc1T2SNr3VIzRmzRNUbE2hKxdgUM35iQgb3P7tEAQJT8FaC6uGIOWqRBe0xDupV+g==
+"@aws-amplify/api-rest@^2.0.38":
+  version "2.0.38"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/api-rest/-/api-rest-2.0.38.tgz#5e2e698be2e9c451cc3824c61279288ac4500ad7"
+  integrity sha512-KK3bQmeXRZBgzUiV8NP1YLydZLS/K0ROL2xZsnpiCjmv/B3gVvY/wU28gUPVaC0FjRC7a7gtedMBiE/YWoPA2Q==
   dependencies:
-    "@aws-amplify/api-rest" "2.0.37"
-    "@aws-amplify/auth" "4.5.1"
-    "@aws-amplify/cache" "4.0.39"
-    "@aws-amplify/core" "4.5.1"
-    "@aws-amplify/pubsub" "4.3.1"
-    graphql "15.8.0"
-    uuid "^3.2.1"
-    zen-observable-ts "0.8.19"
-
-"@aws-amplify/api-rest@2.0.37":
-  version "2.0.37"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/api-rest/-/api-rest-2.0.37.tgz#f56e71149f4b8017d225560c2226a534cd57d3f7"
-  integrity sha512-Hx5qnPsREtyt8Bja/951fj5rP2jUsH7AF+Lh0V447Bm43UcRQ0MrcgiKNLMflQt0/BBezInmnkXqfPR6YIES3g==
-  dependencies:
-    "@aws-amplify/core" "4.5.1"
+    "@aws-amplify/core" "4.5.2"
     axios "0.21.4"
 
-"@aws-amplify/api@^4.0.33":
-  version "4.0.37"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/api/-/api-4.0.37.tgz#b6f25bb048515836fb47663c7397f3713691c11d"
-  integrity sha512-8oPhX7NvzRo7QoeSZniebn2kgOxiXNegX45yEi5bDoxTxGNT2pMT37N0fDD3VxhP23+1ggPa+zHJh6hHZI+iXQ==
-  dependencies:
-    "@aws-amplify/api-graphql" "2.3.1"
-    "@aws-amplify/api-rest" "2.0.37"
-
-"@aws-amplify/auth@4.5.1", "@aws-amplify/auth@^4.4.2":
+"@aws-amplify/auth@^4.4.2":
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/@aws-amplify/auth/-/auth-4.5.1.tgz#a3d6c2ce58e3976bf7eeebffee8620c86ce3b11c"
   integrity sha512-c95Np9usoclAywk4bKPGQB/8iQ8L9n9pX/QqSt2coDlm21Ys+a89WwzLhF/tSFUFnPNF2azw4F7I5RP6HzRbnQ==
@@ -79,17 +57,18 @@
     universal-cookie "^4.0.4"
     zen-observable-ts "0.8.19"
 
-"@aws-amplify/pubsub@4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/pubsub/-/pubsub-4.3.1.tgz#ab3eff626bbb719b61ece6003b833e28f8e5ca68"
-  integrity sha512-cSUjS6IFgixFZBUSAktVxD6uR4Obskz0Zy5cqFOqMG7XRoEixWUL6LBMmyACKe/12t/UbMgGNuaUA3ZqjtNy/A==
+"@aws-amplify/core@4.5.2":
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/core/-/core-4.5.2.tgz#fba7466293ecc2e642d20fcfd98038116bcf3bf0"
+  integrity sha512-FTPK59RlrPXPpZnrYhVX/8+7K5rt6p7Xf3Uz/kQLd6KDkZla8lSVtPXn3RvpRtD7XzreB0sAINlRMm3ppvXNzQ==
   dependencies:
-    "@aws-amplify/auth" "4.5.1"
-    "@aws-amplify/cache" "4.0.39"
-    "@aws-amplify/core" "4.5.1"
-    graphql "15.8.0"
-    paho-mqtt "^1.1.0"
-    uuid "^3.2.1"
+    "@aws-crypto/sha256-js" "1.0.0-alpha.0"
+    "@aws-sdk/client-cloudwatch-logs" "3.6.1"
+    "@aws-sdk/client-cognito-identity" "3.6.1"
+    "@aws-sdk/credential-provider-cognito-identity" "3.6.1"
+    "@aws-sdk/types" "3.6.1"
+    "@aws-sdk/util-hex-encoding" "3.6.1"
+    universal-cookie "^4.0.4"
     zen-observable-ts "0.8.19"
 
 "@aws-amplify/storage@^4.4.16":
@@ -6473,11 +6452,6 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, 
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graphql@15.8.0:
-  version "15.8.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
-  integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
-
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
@@ -8579,11 +8553,6 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
-
-paho-mqtt@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/paho-mqtt/-/paho-mqtt-1.1.0.tgz#8c10e29eb162e966fb15188d965c3dce505de9d9"
-  integrity sha512-KPbL9KAB0ASvhSDbOrZBaccXS+/s7/LIofbPyERww8hM5Ko71GUJQ6Nmg0BWqj8phAIT8zdf/Sd/RftHU9i2HA==
 
 param-case@^3.0.4:
   version "3.0.4"
@@ -11218,7 +11187,7 @@ uuid@8.3.2, uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-uuid@^3.0.0, uuid@^3.2.1:
+uuid@^3.0.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Pull-Request for `paretOS`

## Description
- Uses @aws-amplify/api-rest instead of @aws-amplify/api
- Eliminates need for GraphQL dependency bundle
- Reduces bundle size by ~100kb
- Fixes deprecated default imports for Amplify API, Storage, and Auth

I'm still experimenting, but I believe we'll initially want to just replace the Amplify API with fetch (unless you decide we're concerned about supporting IE and Opera Mini). So far it doesn't look like there's anything we need the API module to do at present (even sending auth headers) that can't be done in ~50 lines of code with a custom RestAPI class based around fetch.  

React-Query has some great features, but I'm not sure most of the bells & whistles currently apply to the needs of the project (even the data caching... I'm pretty sure there are ways to accomplish the same effect using React hooks.) 

If the main goals are to maximize bundle size reduction and enable better offline data access, using lightweight native JavaScript & React methods might be the best way to go. 

## Relates to
- #191 

## Reviewers
- @mikhael28 

### Screenshots / other info
I've tested each type of method (get/post/delete), but not absolutely every time that method is used (about ~60% testing coverage.) Could definitely use some help or suggestions identifying edge cases to test. So far it seems like a seamless transition. 
<img width="1286" alt="Screen Shot 2022-04-22 at 11 10 33 AM" src="https://user-images.githubusercontent.com/84106309/164745189-51b43b5a-0f97-478d-bc7a-9219a49c84ca.png">
<img width="1287" alt="Screen Shot 2022-04-22 at 11 10 24 AM" src="https://user-images.githubusercontent.com/84106309/164745195-b3ce5c12-5971-4ad0-b2a3-5a66c6e160e0.png">

