### PR TITLE
ArenaDateHeader and <section> in TabPanel

### DIFF
--- a/src/arena/Sprint.js
+++ b/src/arena/Sprint.js
@@ -236,7 +236,7 @@ function Sprint(props) {
           <TabPanel value={key} index={1}>
             <>
               <section>
-                <h5>{getFormattedDay(startDate)}</h5>
+                <h5>{getFormattedDay(startDate, displayDay)}</h5>
               </section>
 
               <ArenaStats

--- a/src/utils/getDateRange.ts
+++ b/src/utils/getDateRange.ts
@@ -12,7 +12,7 @@ const getDateRange = (startDate: Date) => {
   const endMonth = end.getMonth();
   const endDate = end.getDate();
 
-  return `${beginMonth + 1}/${beginDate + 1} - ${endMonth + 1}/${endDate + 1}`;
+  return `${beginMonth + 1}/${beginDate} - ${endMonth + 1}/${endDate}`;
 };
 
 export default getDateRange;

--- a/src/utils/getFormattedDay.ts
+++ b/src/utils/getFormattedDay.ts
@@ -1,17 +1,25 @@
 /**
  * This function returns the formatted day.
  * @param startDate date to be formatted
+ * @param displayDay index of the day to display
  * @returns date in the format of "day, month/date"
  * @example getFormattedDay("2020-01-01") returns "Tuesday, 12/17"
  */
-function getFormattedDay(startDate: Date) {
-  const days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
+function getFormattedDay(startDate: Date, displayDay): string {
+  const days = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ];
 
   const month = startDate.getMonth();
   const dayOfWeek = startDate.getDay();
   const date = startDate.getDate();
-
-  return `${days[dayOfWeek]}, ${month + 1}/${date + 1}`;
+  return `${days[dayOfWeek]}, ${month + 1}/${date + displayDay}`;
 }
 
 export default getFormattedDay;


### PR DESCRIPTION
Pull-Request for `paretOS`

## Description
removed the +1 in getDateRange and getFormattedDay that was causing the days to be one day ahead
in getFor4mattedDay added displayDay param and had it add displayDay. displayDay starts at 0 and goes to 5 when clicking on the days in time travel, which causes the days to move ahead depending on day clicked.  added displayDay to the params in Sprint.js in line 239 ```{getFormattedDay(startDate, displayDay)}```

## Relates to
- #3210

## Reviewers
- @person1 (merge duty)
- @person2
- ...

## Steps to reproduce (if describing bug fix)
- Start project
- Make request to `/endpoint` with `{ "body": "test" }`
- Expect some response

## Screenshots / other info
...
![image](https://user-images.githubusercontent.com/63400531/164988664-c9cf45df-d438-4fbd-90a4-e3213988042f.png)

the above has day 2 clicked and its showing the 9th

![image](https://user-images.githubusercontent.com/63400531/164988686-85803a2f-7e4a-4f68-85c6-eea6a462fee4.png)

