### PR TITLE
Fix sprint initial fetch bug

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -175,9 +175,9 @@ class App extends Component {
           secondFetch.push(() => fetchStarterKitExperience(currentUser.id));
         }
         if (arena) {
-          firstFetch.push(() => this.connectSocketToSprint());
+          firstFetch.push(() => this.connectSocketToSprint(currentUser.id));
         } else {
-          secondFetch.push(() => this.connectSocketToSprint());
+          secondFetch.push(() => this.connectSocketToSprint(currentUser.id));
         }
         if (currentUser.instructor) {
           firstFetch.push(() => fetchCoachingRoster(currentUser.id));
@@ -226,15 +226,12 @@ class App extends Component {
     }
   };
 
-  connectSocketToSprint = async () => {
+  connectSocketToSprint = async (userID = this.state.user.id) => {
     let result = { success: false, sprints: null };
     try {
-      const sprints = await RestAPI.get(
-        "pareto",
-        `/sprints/mentee/${this.state.user.id}`
-      );
+      const sprints = await RestAPI.get("pareto", `/sprints/mentee/${userID}`);
       result.success = true;
-      result.sprints = sprints;
+      result.sprints = await sprints;
 
       this.props.getInitialSprintData(sprints);
       this.setState({ sprints: sprints });


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Pull-Request for `paretOS`

## Description
Fixes initial sprint fetching bug. I think I must have written over my own commit at some point - when connectSocketToSprint is called in the sprint creation process, it runs off of the user id stored in state. However it also needs to be able to accept a direct userID argument because when it is initially called in the site loading process, user state has usually not yet updated (so there is no userID stored in state for the method to draw from.)

## Relates to
Fixes #225 

## Reviewers
- @mikhael28 