### PR TITLE
Show prompts for input required and cannot select date out of valid r…

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -991,6 +991,11 @@ details[open] summary {
   overflow-y: scroll;
 }
 
+.react-calendar__create-sprints {
+	color: black;
+}
+
+
 /* Messaging styles */
 
 * {

--- a/src/libs/strings.ts
+++ b/src/libs/strings.ts
@@ -70,6 +70,12 @@ export const strings = {
     startSprint: "Start a Sprint",
     sprintDescription:
       "Sprints are 5-Day events where you measure your ability to perform at the highest level. Currently, sprints must start on a Monday and Finish on a Friday.",
+    selectSprintDate: "Choose Your Sprint Start",
+    selectSprintDateHelper: "Valid dates include from today to 90 days out.",
+    sprintDateError:
+      "Cannot create sprint that starts before today or more than 90 days from now.",
+    sprintChooseTemplateError:
+      "You must seelct a sprint template before starting a sprint.",
     create: "Create",
 
     pageNoExist: "Sorry, this page doesn't exist!",


### PR DESCRIPTION
This pull makes updates to `arena/create/sprints`: `SprintCreation.js`

## Description
- User cannot select date before today or more than 90 days in the future.
- Create Sprint button is disabled until a valid date and a sprint template has been selected
- Updates react-calendar with class added to `index.css` to fix tile coloring (see image below for before and after)
- Adds Label and helper text for calendar
- Adds error alert under create button if input is not valid

## Relates to
- #231 

## Screenshots
### Calendar Before (taken from live site)
![image](https://user-images.githubusercontent.com/31998568/166852263-7e6127b1-3456-4794-932b-d573aa88a9c5.png)

### Calendar After (running locally)
![image](https://user-images.githubusercontent.com/31998568/166852339-aaa88244-7023-4018-b607-11dee4f01071.png)
