### PR TITLE
update: updated nanoid to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jsdom": "20.0.1",
     "lodash.clonedeep": "4.5.0",
     "lodash.sortby": "4.7.0",
-    "nanoid": "3.3.4",
+    "nanoid": "4.0.0",
     "ninja-keys": "1.2.2",
     "pell": "1.0.6",
     "prop-types": ">=15.6.2 <16.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ specifiers:
   lodash.clonedeep: 4.5.0
   lodash.sortby: 4.7.0
   mocha: 10.1.0
-  nanoid: 3.3.4
+  nanoid: 4.0.0
   ninja-keys: 1.2.2
   pell: 1.0.6
   prettier: 2.7.1
@@ -138,7 +138,7 @@ dependencies:
   jsdom: 20.0.1
   lodash.clonedeep: 4.5.0
   lodash.sortby: 4.7.0
-  nanoid: 3.3.4
+  nanoid: 4.0.0
   ninja-keys: 1.2.2
   pell: 1.0.6
   prop-types: 15.8.1
@@ -8056,6 +8056,12 @@ packages:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  /nanoid/4.0.0:
+    resolution: {integrity: sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==}
+    engines: {node: ^14 || ^16 || >=18}
+    hasBin: true
+    dev: false
 
   /nanomatch/1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}


### PR DESCRIPTION
Pull-Request for `paretOS`

## Description
updated nanoid to version 4, no errors except for experience module didnt work, but I seem to remember you saying that you shut it down on purpose as you were reworking it.

## Relates to
- #330 

## Reviewers
- @person1 (merge duty)
- @person2
- ...

