### PR TITLE
Update deps and fix ci for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies   
-        run: pnpm install
+        run: pnpm install --frozen-lockfile false
 
       - name: Run unit tests
         run: pnpm test:unit
@@ -45,5 +45,4 @@ jobs:
         run: |
           pnpm run start &
           sleep 45 &&
-          curl http://localhost:5173 &&
           pnpm test:integration

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.1",
   "private": true,
   "dependencies": {
-    "@aws-amplify/api-rest": "2.0.60",
+    "@aws-amplify/api-rest": "3.0.11",
     "@aws-amplify/auth": "4.6.10",
     "@aws-amplify/core": "4.7.8",
     "@aws-amplify/storage": "4.5.10",
@@ -11,7 +11,7 @@
     "@emotion/react": "11.10.5",
     "@emotion/styled": "11.10.5",
     "@hookform/resolvers": "2.9.10",
-    "@mui/material": "5.11.4",
+    "@mui/material": "5.11.5",
     "@mui/styles": "5.11.2",
     "@mui/system": "5.11.4",
     "@mui/x-date-pickers": "5.0.14",
@@ -22,7 +22,7 @@
     "@rollup/plugin-node-resolve": "15.0.1",
     "@sanity/client": "4.0.1",
     "@sanity/image-url": "1.0.1",
-    "@sentry/react": "7.31.0",
+    "@sentry/react": "7.31.1",
     "@sentry/tracing": "7.31.0",
     "@stripe/stripe-js": "1.46.0",
     "@testing-library/react": "13.4.0",
@@ -134,10 +134,45 @@
     "peerDependencyRules": {
       "ignoreMissing": [
         "*",
-        "react-native"
+        "react-native",
+        "react",
+        "react-dom"
       ]
     },
     "packageExtensions": {
+      "@mui/styles": {
+        "dependencies": {
+          "@types/react": "18.0.26",
+          "react": "18.2.0"
+        }
+      },
+      "use-memo-one": {
+        "dependencies": {
+          "react": "18.2.0"
+        }
+      },
+      "@stripe/react-stripe-js": {
+        "dependencies": {
+          "react": "18.2.0",
+          "react-dom": "18.2.0"
+        }
+      },
+      "react-focus-lock": {
+        "dependencies": {
+          "react": "18.2.0"
+        }
+      },
+      "react-konva": {
+        "dependencies": {
+          "react": "18.2.0",
+          "react-dom": "18.2.0"
+        }
+      },
+      "react-reconciler": {
+        "dependencies": {
+          "react": "18.2.0"
+        }
+      },
       "reactour": {
         "dependencies": {
           "styled-components": "*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,9 @@
 lockfileVersion: 5.4
 
-packageExtensionsChecksum: 93ec16a3b368a4ce097b8f5a256e744f
+packageExtensionsChecksum: 9c115b917b4305463c032ae4dc497ae0
 
 specifiers:
-  '@aws-amplify/api-rest': 2.0.60
+  '@aws-amplify/api-rest': 3.0.11
   '@aws-amplify/auth': 4.6.10
   '@aws-amplify/core': 4.7.8
   '@aws-amplify/storage': 4.5.10
@@ -11,7 +11,7 @@ specifiers:
   '@emotion/react': 11.10.5
   '@emotion/styled': 11.10.5
   '@hookform/resolvers': 2.9.10
-  '@mui/material': 5.11.4
+  '@mui/material': 5.11.5
   '@mui/styles': 5.11.2
   '@mui/system': 5.11.4
   '@mui/types': 7.2.3
@@ -23,7 +23,7 @@ specifiers:
   '@rollup/plugin-node-resolve': 15.0.1
   '@sanity/client': 4.0.1
   '@sanity/image-url': 1.0.1
-  '@sentry/react': 7.31.0
+  '@sentry/react': 7.31.1
   '@sentry/tracing': 7.31.0
   '@stripe/stripe-js': 1.46.0
   '@testing-library/react': 13.4.0
@@ -112,7 +112,7 @@ specifiers:
   yup: 0.32.11
 
 dependencies:
-  '@aws-amplify/api-rest': 2.0.60_react-native@0.71.0
+  '@aws-amplify/api-rest': 3.0.11_react-native@0.71.0
   '@aws-amplify/auth': 4.6.10_react-native@0.71.0
   '@aws-amplify/core': 4.7.8_react-native@0.71.0
   '@aws-amplify/storage': 4.5.10_react-native@0.71.0
@@ -120,10 +120,10 @@ dependencies:
   '@emotion/react': 11.10.5_kzbn2opkn2327fwg5yzwzya5o4
   '@emotion/styled': 11.10.5_qvatmowesywn4ye42qoh247szu
   '@hookform/resolvers': 2.9.10_react-hook-form@7.42.1
-  '@mui/material': 5.11.4_lskpmcsdi7ipu6qpuapyu56ihm
-  '@mui/styles': 5.11.2_kzbn2opkn2327fwg5yzwzya5o4
+  '@mui/material': 5.11.5_lskpmcsdi7ipu6qpuapyu56ihm
+  '@mui/styles': 5.11.2
   '@mui/system': 5.11.4_ogriz7mfahdh34qnfautfro5yu
-  '@mui/x-date-pickers': 5.0.14_xlpj4z6and7qzbr7s6ieu2da4q
+  '@mui/x-date-pickers': 5.0.14_6ixi66hsnl2xepv6okilu7ivqq
   '@portabletext/react': 2.0.0_react@18.2.0
   '@react-three/drei': 9.53.0_xrskfjgmwd72lb724i4wvop5hq
   '@react-three/fiber': 8.10.0_lykdi52vkvnquhdw4c4cmmzv4q
@@ -131,7 +131,7 @@ dependencies:
   '@rollup/plugin-node-resolve': 15.0.1_rollup@3.10.0
   '@sanity/client': 4.0.1
   '@sanity/image-url': 1.0.1
-  '@sentry/react': 7.31.0_react@18.2.0
+  '@sentry/react': 7.31.1_react@18.2.0
   '@sentry/tracing': 7.31.0
   '@stripe/stripe-js': 1.46.0
   '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y
@@ -163,8 +163,8 @@ dependencies:
   react-redux: 8.0.5_p2l4gn5uto5qachobdlyyhxppa
   react-router-dom: 6.6.2_biqbaboplfbrettd7655fr4n2y
   react-spring: 9.6.1_6zn7apoi5abdfwl3dq64whovze
-  react-stripe-js: 1.1.2_biqbaboplfbrettd7655fr4n2y
-  reactour: 1.19.0_id224sjdtybtv2oolemsd5viba
+  react-stripe-js: 1.1.2_react@18.2.0
+  reactour: 1.19.0_oey2skiwbnon6xiwiangfbg2je
   redux: 4.2.0
   remark-gfm: 3.0.1
   rollup: 3.10.0
@@ -236,9 +236,6 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       ajv: '>=8'
-    peerDependenciesMeta:
-      ajv:
-        optional: true
     dependencies:
       ajv: 8.11.0
       json-schema: 0.4.0
@@ -246,11 +243,12 @@ packages:
       leven: 3.1.0
     dev: true
 
-  /@aws-amplify/api-rest/2.0.60_react-native@0.71.0:
-    resolution: {integrity: sha512-MQFDWDfNB1EsWBW4VG92Xc36zryHMJGgFsBxVpf0C/GBy9AAJou/CkyXTWJGRvzKBSVDBL/n8YqWOvyYEbL/gg==}
+  /@aws-amplify/api-rest/3.0.11_react-native@0.71.0:
+    resolution: {integrity: sha512-Ag7R0KoMVF3hoeewJkyZa+bK3LShQJnj1V+LIi+E+MoY83lP13U9ZDDdDKhcgecL9QZDaFxgz6ClGoYKhgFpZg==}
     dependencies:
-      '@aws-amplify/core': 4.7.11_react-native@0.71.0
+      '@aws-amplify/core': 5.0.11_react-native@0.71.0
       axios: 0.26.0
+      tslib: 1.14.1
     transitivePeerDependencies:
       - debug
       - react-native
@@ -276,8 +274,8 @@ packages:
       - react-native
     dev: false
 
-  /@aws-amplify/core/4.7.11_react-native@0.71.0:
-    resolution: {integrity: sha512-Gfn9V66wgnyWi/dUzYfjmqbYxRdpeY1MH6jqCWXMWPHIBA7yPtac4xHpNK886TOuvekUK7HRI91Lvl//XKueOw==}
+  /@aws-amplify/core/4.7.8_react-native@0.71.0:
+    resolution: {integrity: sha512-mPBB0PXZf6AgX2uBhz4NyhGYEk+XD9YNZLmpMNw8WWiKOcoh4yZCJtGyQ7godGbqNnHTxHVzQpq37AU/U8T1TA==}
     dependencies:
       '@aws-crypto/sha256-js': 1.0.0-alpha.0
       '@aws-sdk/client-cloudwatch-logs': 3.6.1_react-native@0.71.0
@@ -291,15 +289,16 @@ packages:
       - react-native
     dev: false
 
-  /@aws-amplify/core/4.7.8_react-native@0.71.0:
-    resolution: {integrity: sha512-mPBB0PXZf6AgX2uBhz4NyhGYEk+XD9YNZLmpMNw8WWiKOcoh4yZCJtGyQ7godGbqNnHTxHVzQpq37AU/U8T1TA==}
+  /@aws-amplify/core/5.0.11_react-native@0.71.0:
+    resolution: {integrity: sha512-Gcr1yzzI/iBNa7psstyYhyc6QlOc9zknx1J7VaVQ2b7qTGfh6sykDRNvk2vq0qEDNnhDhPHtLx/bQsGeyuA0Lg==}
     dependencies:
-      '@aws-crypto/sha256-js': 1.0.0-alpha.0
+      '@aws-crypto/sha256-js': 1.2.2
       '@aws-sdk/client-cloudwatch-logs': 3.6.1_react-native@0.71.0
       '@aws-sdk/client-cognito-identity': 3.6.1_react-native@0.71.0
       '@aws-sdk/credential-provider-cognito-identity': 3.6.1_react-native@0.71.0
       '@aws-sdk/types': 3.6.1
       '@aws-sdk/util-hex-encoding': 3.6.1
+      tslib: 1.14.1
       universal-cookie: 4.0.4
       zen-observable-ts: 0.8.19
     transitivePeerDependencies:
@@ -1142,15 +1141,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/generator/7.18.13:
-    resolution: {integrity: sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.20.7
-      '@jridgewell/gen-mapping': 0.3.2
-      jsesc: 2.5.2
-    dev: false
-
   /@babel/generator/7.20.7:
     resolution: {integrity: sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==}
     engines: {node: '>=6.9.0'}
@@ -1178,9 +1168,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/compat-data': 7.20.10
       '@babel/core': 7.20.12
@@ -1194,9 +1181,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
@@ -1214,9 +1198,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
@@ -1226,9 +1207,6 @@ packages:
     resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
     peerDependencies:
       '@babel/core': ^7.4.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
@@ -1274,7 +1252,7 @@ packages:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.4
+      '@babel/types': 7.20.7
 
   /@babel/helper-module-transforms/7.20.11:
     resolution: {integrity: sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==}
@@ -1306,9 +1284,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
@@ -1389,14 +1364,6 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
-  /@babel/parser/7.18.13:
-    resolution: {integrity: sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.20.7
-    dev: false
-
   /@babel/parser/7.20.7:
     resolution: {integrity: sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==}
     engines: {node: '>=6.0.0'}
@@ -1409,9 +1376,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1422,9 +1386,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1437,9 +1398,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-environment-visitor': 7.18.9
@@ -1454,9 +1412,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-create-class-features-plugin': 7.18.13_@babel+core@7.20.12
@@ -1469,9 +1424,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-create-class-features-plugin': 7.18.13_@babel+core@7.20.12
@@ -1486,9 +1438,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1500,9 +1449,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1514,9 +1460,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1528,9 +1471,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1542,9 +1482,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1556,9 +1493,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1569,9 +1503,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1583,9 +1514,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/compat-data': 7.20.10
       '@babel/core': 7.20.12
@@ -1599,9 +1527,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1612,9 +1537,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1626,9 +1548,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-create-class-features-plugin': 7.18.13_@babel+core@7.20.12
@@ -1642,9 +1561,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
@@ -1660,9 +1576,6 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.20.12
@@ -1673,9 +1586,6 @@ packages:
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1684,9 +1594,6 @@ packages:
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1696,9 +1603,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1708,9 +1612,6 @@ packages:
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1720,9 +1621,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1732,9 +1630,6 @@ packages:
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1745,9 +1640,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1758,9 +1650,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1770,9 +1659,6 @@ packages:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1783,9 +1669,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/helper-plugin-utils': 7.19.0
     dev: false
@@ -1795,9 +1678,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1807,9 +1687,6 @@ packages:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1819,9 +1696,6 @@ packages:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1830,9 +1704,6 @@ packages:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1842,9 +1713,6 @@ packages:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1853,9 +1721,6 @@ packages:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1864,9 +1729,6 @@ packages:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1876,9 +1738,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1889,9 +1748,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1902,9 +1758,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1915,9 +1768,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1927,9 +1777,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-module-imports': 7.18.6
@@ -1943,9 +1790,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1955,9 +1799,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -1967,9 +1808,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
@@ -1989,9 +1827,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2001,9 +1836,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2013,9 +1845,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.20.12
@@ -2027,9 +1856,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2040,9 +1866,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
@@ -2054,9 +1877,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2068,9 +1888,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2080,9 +1897,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
@@ -2094,9 +1908,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2106,9 +1917,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2118,9 +1926,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-module-transforms': 7.20.11
@@ -2134,9 +1939,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-module-transforms': 7.20.11
@@ -2151,9 +1953,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-hoist-variables': 7.18.6
@@ -2169,9 +1968,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-module-transforms': 7.20.11
@@ -2185,9 +1981,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.20.12
@@ -2198,9 +1991,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2211,9 +2001,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2226,9 +2013,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2238,9 +2022,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2250,9 +2031,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2263,9 +2041,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2276,9 +2051,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2289,9 +2061,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
@@ -2306,9 +2075,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2320,9 +2086,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2333,9 +2096,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-module-imports': 7.18.6
@@ -2353,9 +2113,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2365,9 +2122,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2378,9 +2132,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2390,9 +2141,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2402,9 +2150,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2415,9 +2160,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-create-class-features-plugin': 7.18.13_@babel+core@7.20.12
@@ -2432,9 +2174,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2445,9 +2184,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.20.12
@@ -2458,9 +2194,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/compat-data': 7.20.10
       '@babel/core': 7.20.12
@@ -2547,9 +2280,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2561,9 +2291,6 @@ packages:
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2578,9 +2305,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.19.0
@@ -2595,9 +2319,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       clone-deep: 4.0.1
@@ -2607,12 +2328,12 @@ packages:
       source-map-support: 0.5.21
     dev: false
 
-  /@babel/runtime-corejs2/7.18.9:
-    resolution: {integrity: sha512-l057ZarpDX2QnXM89ViR2BgRFgTy2l5UFGDt0SbInhim1N/ljBgPeTJV0kRG1/Bo7CkHfYfrNNwTeQ2CPph9xQ==}
+  /@babel/runtime-corejs2/7.20.13:
+    resolution: {integrity: sha512-K2yRNithMJG4epI509n4ljPjogMhmYCB887iSD7rRecxWC9dkbfJZCPGj0BQaqG3d3Qkpb1SotEmyeMmtnvxhw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       core-js: 2.6.12
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
     dev: false
 
   /@babel/runtime/7.18.9:
@@ -2626,7 +2347,7 @@ packages:
     resolution: {integrity: sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
     dev: false
 
   /@babel/runtime/7.20.7:
@@ -2648,13 +2369,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.18.13
+      '@babel/generator': 7.20.7
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.18.13
-      '@babel/types': 7.19.4
+      '@babel/parser': 7.20.7
+      '@babel/types': 7.20.7
       debug: 4.3.4_supports-color@5.5.0
       globals: 11.12.0
     transitivePeerDependencies:
@@ -2677,14 +2398,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/types/7.19.4:
-    resolution: {integrity: sha512-M5LK7nAeS6+9j7hAq+b3fQs+pNfUtTGq+yFFfHnauFA8zQtLRfmuipmsKDKKLuyG+wC8ABW43A153YNawNTEtw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-string-parser': 7.19.4
-      '@babel/helper-validator-identifier': 7.19.1
-      to-fast-properties: 2.0.0
 
   /@babel/types/7.20.7:
     resolution: {integrity: sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==}
@@ -2734,11 +2447,6 @@ packages:
     peerDependencies:
       postcss: ^8.2
       postcss-selector-parser: ^6.0.10
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      postcss-selector-parser:
-        optional: true
     dependencies:
       postcss: 8.4.21
       postcss-selector-parser: 6.0.11
@@ -2797,9 +2505,6 @@ packages:
     resolution: {integrity: sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==}
     peerDependencies:
       '@babel/core': ^7.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/helper-module-imports': 7.18.6
       '@babel/plugin-syntax-jsx': 7.18.6
@@ -2888,8 +2593,6 @@ packages:
       react: '>=16.8.0'
     peerDependenciesMeta:
       '@babel/core':
-        optional: true
-      '@emotion/react':
         optional: true
       '@types/react':
         optional: true
@@ -3145,9 +2848,6 @@ packages:
     resolution: {integrity: sha512-JIL1DgJIlH9yuxcNGtyhsWX/PgNltz+5Gr6+8SX9fhXc/hPbEIk6wPI82nhgvp3uUb6ZfAM5mqg/x7KR7NAb+A==}
     peerDependencies:
       react-hook-form: ^7.0.0
-    peerDependenciesMeta:
-      react-hook-form:
-        optional: true
     dependencies:
       react-hook-form: 7.42.1_react@18.2.0
     dev: false
@@ -3303,8 +3003,8 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@mui/base/5.0.0-alpha.113_ib3m5ricvtkl2cll7qpr2f6lvq:
-    resolution: {integrity: sha512-XSjvyQWATM8uk+EJZvYna8D21kOXC42lwb3q4K70btuGieKlCIQLaHTTDV2OfD4+JfT4o3NJy3I4Td2co31RZA==}
+  /@mui/base/5.0.0-alpha.114_ib3m5ricvtkl2cll7qpr2f6lvq:
+    resolution: {integrity: sha512-ZpsG2I+zTOAnVTj3Un7TxD2zKRA2OhEPGMcWs/9ylPlS6VuGQSXowPooZiqarjT7TZ0+1bOe8titk/t8dLFiGw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
@@ -3331,12 +3031,12 @@ packages:
       react-is: 18.2.0
     dev: false
 
-  /@mui/core-downloads-tracker/5.11.4:
-    resolution: {integrity: sha512-jWVwGM3vG4O0sXcW0VcIl+njCWbGCBF5vvjRpuKJajrz51AD7D6+fP1SkInZXVk5pRHf6Bnk/Yj9Of9gXxb/hA==}
+  /@mui/core-downloads-tracker/5.11.5:
+    resolution: {integrity: sha512-MIuWGjitOsugpRhp64CQY3ZEVMIu9M/L9ioql6QLSkz73+bGIlC9FEhfi670/GZ8pQIIGmtiGGwofYzlwEWjig==}
     dev: false
 
-  /@mui/material/5.11.4_lskpmcsdi7ipu6qpuapyu56ihm:
-    resolution: {integrity: sha512-ZL/czK9ynrQJ6uyDwQgK+j7m1iKA1XKPON+rEPupwAu/bJ1XJxD+H/H2bkMM8UpOkzaucx/WuMbJJGQ60l7gBg==}
+  /@mui/material/5.11.5_lskpmcsdi7ipu6qpuapyu56ihm:
+    resolution: {integrity: sha512-5fzjBbRYaB5MoEpvA32oalAWltOZ3/kSyuovuVmPc6UF6AG42lTtbdMLpdCygurFSGUMZYTg4Cjij52fKlDDgg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -3359,9 +3059,9 @@ packages:
       '@babel/runtime': 7.20.7
       '@emotion/react': 11.10.5_kzbn2opkn2327fwg5yzwzya5o4
       '@emotion/styled': 11.10.5_qvatmowesywn4ye42qoh247szu
-      '@mui/base': 5.0.0-alpha.113_ib3m5ricvtkl2cll7qpr2f6lvq
-      '@mui/core-downloads-tracker': 5.11.4
-      '@mui/system': 5.11.4_ogriz7mfahdh34qnfautfro5yu
+      '@mui/base': 5.0.0-alpha.114_ib3m5ricvtkl2cll7qpr2f6lvq
+      '@mui/core-downloads-tracker': 5.11.5
+      '@mui/system': 5.11.5_ogriz7mfahdh34qnfautfro5yu
       '@mui/types': 7.2.3_@types+react@18.0.26
       '@mui/utils': 5.11.2_react@18.2.0
       '@types/react': 18.0.26
@@ -3418,12 +3118,9 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@mui/styles/5.11.2_kzbn2opkn2327fwg5yzwzya5o4:
+  /@mui/styles/5.11.2:
     resolution: {integrity: sha512-Yg6+PMPV4Mx1UJHow2e/nND2bQNWS1H38zrkJxlucXfaR0+aglO6u8R/OXmVspDj+Z5YW5B27lxRDvxCQN9nGw==}
     engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@types/react': ^17.0.0
-      react: ^17.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3483,6 +3180,38 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@mui/system/5.11.5_ogriz7mfahdh34qnfautfro5yu:
+    resolution: {integrity: sha512-KNVsJ0sgRRp2XBqhh4wPS5aacteqjwxgiYTVwVnll2fgkgunZKo3DsDiGMrFlCg25ZHA3Ax58txWGE9w58zp0w==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.7
+      '@emotion/react': 11.10.5_kzbn2opkn2327fwg5yzwzya5o4
+      '@emotion/styled': 11.10.5_qvatmowesywn4ye42qoh247szu
+      '@mui/private-theming': 5.11.2_kzbn2opkn2327fwg5yzwzya5o4
+      '@mui/styled-engine': 5.11.0_dovxhg2tvkkxkdnqyoum6wzcxm
+      '@mui/types': 7.2.3_@types+react@18.0.26
+      '@mui/utils': 5.11.2_react@18.2.0
+      '@types/react': 18.0.26
+      clsx: 1.2.1
+      csstype: 3.1.1
+      prop-types: 15.8.1
+      react: 18.2.0
+    dev: false
+
   /@mui/types/7.2.3_@types+react@18.0.26:
     resolution: {integrity: sha512-tZ+CQggbe9Ol7e/Fs5RcKwg/woU+o8DCtOnccX6KmbBc7YrfqMYEYuaIcXHuhpT880QwNkZZ3wQwvtlDFA2yOw==}
     peerDependencies:
@@ -3510,7 +3239,7 @@ packages:
       react-is: 18.2.0
     dev: false
 
-  /@mui/x-date-pickers/5.0.14_xlpj4z6and7qzbr7s6ieu2da4q:
+  /@mui/x-date-pickers/5.0.14_6ixi66hsnl2xepv6okilu7ivqq:
     resolution: {integrity: sha512-+k+YOL++wEwuF6XRhF3uMLOXlHkUjMHmbXOXWWZ9wJppaGFolj9fNmUvydCp3Z0E9dPRt8J5Vv0z+upZ9KyQZg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -3528,10 +3257,6 @@ packages:
       '@emotion/react':
         optional: true
       '@emotion/styled':
-        optional: true
-      '@mui/material':
-        optional: true
-      '@mui/system':
         optional: true
       date-fns:
         optional: true
@@ -3554,7 +3279,7 @@ packages:
       '@date-io/moment': 2.15.0
       '@emotion/react': 11.10.5_kzbn2opkn2327fwg5yzwzya5o4
       '@emotion/styled': 11.10.5_qvatmowesywn4ye42qoh247szu
-      '@mui/material': 5.11.4_lskpmcsdi7ipu6qpuapyu56ihm
+      '@mui/material': 5.11.5_lskpmcsdi7ipu6qpuapyu56ihm
       '@mui/system': 5.11.4_ogriz7mfahdh34qnfautfro5yu
       '@mui/utils': 5.11.2_react@18.2.0
       '@types/react-transition-group': 4.4.5
@@ -3899,11 +3624,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-konva: ^16.8.0 || ^17.0.0
     peerDependenciesMeta:
-      konva:
-        optional: true
       react:
-        optional: true
-      react-konva:
         optional: true
     dependencies:
       '@react-spring/animated': 9.6.1_react@18.2.0
@@ -3973,11 +3694,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       three: '>=0.126'
     peerDependenciesMeta:
-      '@react-three/fiber':
-        optional: true
       react:
-        optional: true
-      three:
         optional: true
     dependencies:
       '@react-spring/animated': 9.5.5_react@18.2.0
@@ -3996,11 +3713,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       three: '>=0.126'
     peerDependenciesMeta:
-      '@react-three/fiber':
-        optional: true
       react:
-        optional: true
-      three:
         optional: true
     dependencies:
       '@react-spring/animated': 9.6.1_react@18.2.0
@@ -4051,10 +3764,6 @@ packages:
         optional: true
       react-dom:
         optional: true
-      react-zdog:
-        optional: true
-      zdog:
-        optional: true
     dependencies:
       '@react-spring/animated': 9.6.1_react@18.2.0
       '@react-spring/core': 9.6.1_react@18.2.0
@@ -4072,13 +3781,9 @@ packages:
       react-dom: '>=18.0'
       three: '>=0.137'
     peerDependenciesMeta:
-      '@react-three/fiber':
-        optional: true
       react:
         optional: true
       react-dom:
-        optional: true
-      three:
         optional: true
     dependencies:
       '@babel/runtime': 7.20.7
@@ -4131,8 +3836,6 @@ packages:
         optional: true
       react-native:
         optional: true
-      three:
-        optional: true
     dependencies:
       '@babel/runtime': 7.20.7
       '@types/react-reconciler': 0.26.7
@@ -4140,7 +3843,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-native: 0.71.0_react@18.2.0
-      react-reconciler: 0.27.0_react@18.2.0
+      react-reconciler: 0.27.0
       react-use-measure: 2.1.1_biqbaboplfbrettd7655fr4n2y
       scheduler: 0.21.0
       suspend-react: 0.0.8_react@18.2.0
@@ -4180,11 +3883,7 @@ packages:
       '@types/babel__core': ^7.1.9
       rollup: ^1.20.0||^2.0.0
     peerDependenciesMeta:
-      '@babel/core':
-        optional: true
       '@types/babel__core':
-        optional: true
-      rollup:
         optional: true
     dependencies:
       '@babel/core': 7.20.12
@@ -4198,9 +3897,6 @@ packages:
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.79.1
       '@types/resolve': 1.17.1
@@ -4233,9 +3929,6 @@ packages:
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.79.1
       magic-string: 0.25.9
@@ -4261,9 +3954,6 @@ packages:
     engines: {node: '>= 8.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
@@ -4325,14 +4015,14 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /@sentry/browser/7.31.0:
-    resolution: {integrity: sha512-1ui2rbR6lNPXUOZOCLpa2+YZXhx0AbPgBD/RoC/OHVus3sAs+CyyMR1wBzmI5H3ZhA5jwwzelh4ivt+gQZ24rw==}
+  /@sentry/browser/7.31.1:
+    resolution: {integrity: sha512-Rg9F61S1tz1Dv3iUyyGP26bxoi7WJAG2+f2fBbSmFuJ+JTH4Jvu2/F1bBig8Dz01ejzVhbNSUUCfoDhSvksIsQ==}
     engines: {node: '>=8'}
     dependencies:
-      '@sentry/core': 7.31.0
-      '@sentry/replay': 7.31.0
-      '@sentry/types': 7.31.0
-      '@sentry/utils': 7.31.0
+      '@sentry/core': 7.31.1
+      '@sentry/replay': 7.31.1
+      '@sentry/types': 7.31.1
+      '@sentry/utils': 7.31.1
       tslib: 1.14.1
     dev: false
 
@@ -4345,8 +4035,17 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@sentry/react/7.31.0_react@18.2.0:
-    resolution: {integrity: sha512-36Zaeo2OOh8hQF0ZLaPK3lQp2DpOy59rAE709DBu5ZQYxRkknj2BGlIM7sQottkd53eydjmwOK7WhFu8IO2GcA==}
+  /@sentry/core/7.31.1:
+    resolution: {integrity: sha512-quaNU6z8jabmatBTDi28Wpff2yzfWIp/IU4bbi2QOtEiCNT+TQJXqlRTRMu9xLrX7YzyKCL5X2gbit/85lyWUg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.31.1
+      '@sentry/utils': 7.31.1
+      tslib: 1.14.1
+    dev: false
+
+  /@sentry/react/7.31.1_react@18.2.0:
+    resolution: {integrity: sha512-h65vrF7xVFV+JAvgUJQSqfY4EPU+E4Y39nwjQdnMvdrhb3gjlhOUQTBVGibuM0/bvwm7vBgjfVSBOezavfp6eA==}
     engines: {node: '>=8'}
     peerDependencies:
       react: 15.x || 16.x || 17.x || 18.x
@@ -4354,21 +4053,21 @@ packages:
       react:
         optional: true
     dependencies:
-      '@sentry/browser': 7.31.0
-      '@sentry/types': 7.31.0
-      '@sentry/utils': 7.31.0
+      '@sentry/browser': 7.31.1
+      '@sentry/types': 7.31.1
+      '@sentry/utils': 7.31.1
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
       tslib: 1.14.1
     dev: false
 
-  /@sentry/replay/7.31.0:
-    resolution: {integrity: sha512-/Vb/EcAdvb9zZbNyaAaYjaHXK9XWDoo2lFf7A6DfV+yVf4yaHHraex3pAv0mNs/99LNr55V5eIiwMGhkfeDORg==}
+  /@sentry/replay/7.31.1:
+    resolution: {integrity: sha512-sLArvwZn6IwA/bASctyhxN7LhdCXJvMmyTynRfmk7pzuNzBMc5CNlHeIsDpHrfQuH53IKicvl6cHnHyclu5DSA==}
     engines: {node: '>=12'}
     dependencies:
-      '@sentry/core': 7.31.0
-      '@sentry/types': 7.31.0
-      '@sentry/utils': 7.31.0
+      '@sentry/core': 7.31.1
+      '@sentry/types': 7.31.1
+      '@sentry/utils': 7.31.1
     dev: false
 
   /@sentry/tracing/7.31.0:
@@ -4386,11 +4085,24 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /@sentry/types/7.31.1:
+    resolution: {integrity: sha512-1uzr2l0AxEnxUX/S0EdmXUQ15/kDsam8Nbdw4Gai8SU764XwQgA/TTjoewVP597CDI/AHKan67Y630/Ylmkx9w==}
+    engines: {node: '>=8'}
+    dev: false
+
   /@sentry/utils/7.31.0:
     resolution: {integrity: sha512-B1KkvdfwlaqM7sDp3/yk2No7WsbMuLEywGRVOLzXeTqTLSBRBWyyYIudqPtx2LDds9anlUHj21zs9FKY+S3eiA==}
     engines: {node: '>=8'}
     dependencies:
       '@sentry/types': 7.31.0
+      tslib: 1.14.1
+    dev: false
+
+  /@sentry/utils/7.31.1:
+    resolution: {integrity: sha512-ZsIPq29aNdP9q3R7qIzJhZ9WW+4DzE9g5SfGwx3UjTIxoRRBfdUJUbf7S+LKEdvCkKbyoDt6FLt5MiSJV43xBA==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.31.1
       tslib: 1.14.1
     dev: false
 
@@ -4428,15 +4140,11 @@ packages:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
     dev: false
 
-  /@stripe/react-stripe-js/1.7.2_dg7sxx6zmh46madajf2p7xt5xa:
+  /@stripe/react-stripe-js/1.7.2_@stripe+stripe-js@1.29.0:
     resolution: {integrity: sha512-IAVg2nPUPoSwI//XDRCO7D8mGeK4+N3Xg63fYZHmlfEWAuFVcuaqJKTT67uzIdKYZhHZ/NMdZw/ttz+GOjP/rQ==}
     peerDependencies:
       '@stripe/stripe-js': ^1.26.0
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
     peerDependenciesMeta:
-      '@stripe/stripe-js':
-        optional: true
       react:
         optional: true
       react-dom:
@@ -4832,9 +4540,6 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.0.0
-    peerDependenciesMeta:
-      vite:
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/plugin-transform-react-jsx-self': 7.18.6_@babel+core@7.20.12
@@ -4901,9 +4606,6 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      acorn:
-        optional: true
     dependencies:
       acorn: 8.8.1
     dev: true
@@ -5172,7 +4874,7 @@ packages:
   /axios/0.26.0:
     resolution: {integrity: sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==}
     dependencies:
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.2_debug@4.3.4
     transitivePeerDependencies:
       - debug
     dev: false
@@ -5187,9 +4889,6 @@ packages:
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
     dev: false
@@ -5212,9 +4911,6 @@ packages:
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/compat-data': 7.20.10
       '@babel/core': 7.20.12
@@ -5227,9 +4923,6 @@ packages:
     resolution: {integrity: sha512-zKsXDh0XjnrUEW0mxIHLfjBfnXSMr5Q/goMe/fxpQnLm07mcOZiIZHBNWCMx60HmdvjxfXcalac0tfFg0wqxyw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.12
@@ -5242,9 +4935,6 @@ packages:
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.12
@@ -5257,9 +4947,6 @@ packages:
     resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.12
@@ -5270,9 +4957,6 @@ packages:
     resolution: {integrity: sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==}
     peerDependencies:
       styled-components: '>= 2'
-    peerDependenciesMeta:
-      styled-components:
-        optional: true
     dependencies:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-module-imports': 7.18.6
@@ -5294,9 +4978,6 @@ packages:
     resolution: {integrity: sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==}
     peerDependencies:
       '@babel/core': ^7.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.20.12
@@ -6644,11 +6325,6 @@ packages:
     peerDependencies:
       eslint: ^7.32.0 || ^8.2.0
       eslint-plugin-import: ^2.25.2
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      eslint-plugin-import:
-        optional: true
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.32.0
@@ -6667,17 +6343,6 @@ packages:
       eslint-plugin-jsx-a11y: ^6.5.1
       eslint-plugin-react: ^7.28.0
       eslint-plugin-react-hooks: ^4.3.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      eslint-plugin-import:
-        optional: true
-      eslint-plugin-jsx-a11y:
-        optional: true
-      eslint-plugin-react:
-        optional: true
-      eslint-plugin-react-hooks:
-        optional: true
     dependencies:
       eslint: 8.32.0
       eslint-config-airbnb-base: 15.0.0_ps7hf4l2dvbuxvtusmrfhmzsba
@@ -6694,9 +6359,6 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       eslint: 8.32.0
     dev: true
@@ -6748,8 +6410,6 @@ packages:
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
-      eslint:
-        optional: true
     dependencies:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
@@ -6778,9 +6438,6 @@ packages:
     engines: {node: '>=4.0'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       '@babel/runtime': 7.20.7
       aria-query: 5.1.3
@@ -6809,11 +6466,7 @@ packages:
       eslint-config-prettier: '*'
       prettier: '>=2.0.0'
     peerDependenciesMeta:
-      eslint:
-        optional: true
       eslint-config-prettier:
-        optional: true
-      prettier:
         optional: true
     dependencies:
       eslint: 8.32.0
@@ -6827,9 +6480,6 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       eslint: 8.32.0
     dev: true
@@ -6839,9 +6489,6 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       array-includes: 3.1.6
       array.prototype.flatmap: 1.3.1
@@ -6874,9 +6521,6 @@ packages:
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       eslint: 8.32.0
       eslint-visitor-keys: 2.1.0
@@ -7261,16 +6905,6 @@ packages:
 
   /focus-outline-manager/1.0.2:
     resolution: {integrity: sha512-bHWEmjLsTjGP9gVs7P3Hyl+oY5NlMW8aTSPdTJ+X2GKt6glDctt9fUCLbRV+d/l8NDC40+FxMjp9WlTQXaQALw==}
-    dev: false
-
-  /follow-redirects/1.15.1:
-    resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
     dev: false
 
   /follow-redirects/1.15.2_debug@4.3.4:
@@ -8423,9 +8057,6 @@ packages:
     hasBin: true
     peerDependencies:
       '@babel/preset-env': ^7.1.6
-    peerDependenciesMeta:
-      '@babel/preset-env':
-        optional: true
     dependencies:
       '@babel/core': 7.20.12
       '@babel/parser': 7.20.7
@@ -8849,11 +8480,6 @@ packages:
     peerDependencies:
       '@types/three': '>=0.144.0'
       three: '>=0.144.0'
-    peerDependenciesMeta:
-      '@types/three':
-        optional: true
-      three:
-        optional: true
     dependencies:
       three: 0.148.0
     dev: false
@@ -9079,9 +8705,6 @@ packages:
     resolution: {integrity: sha512-8JZJOdaL5oz3PI/upG8JvP/5FfzYUOhrkJ8np/WKvXzl0/PZ2V9pqTvCIjSKv+w9ccg2xb+yyBhXAwt6ier3ug==}
     peerDependencies:
       three: '>=0.137'
-    peerDependenciesMeta:
-      three:
-        optional: true
     dependencies:
       three: 0.148.0
     dev: false
@@ -9904,7 +9527,7 @@ packages:
     dev: false
 
   /ms/2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    resolution: {integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=}
     dev: false
 
   /ms/2.1.2:
@@ -10441,9 +10064,6 @@ packages:
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.3.3
-    peerDependenciesMeta:
-      postcss:
-        optional: true
     dependencies:
       postcss: 8.4.21
     dev: true
@@ -10677,7 +10297,7 @@ packages:
     dev: false
 
   /querystring/0.2.0:
-    resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
+    resolution: {integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=}
     engines: {node: '>=0.4.x'}
     deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
     dev: false
@@ -10728,7 +10348,7 @@ packages:
       react-dom: 18.2.0_react@18.2.0
       react-redux: 7.2.8_mm6ssz5t7nsja4qwwvdafuklbu
       redux: 4.2.0
-      use-memo-one: 1.1.2_react@18.2.0
+      use-memo-one: 1.1.2
     transitivePeerDependencies:
       - react-native
     dev: false
@@ -10744,7 +10364,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime-corejs2': 7.18.9
+      '@babel/runtime-corejs2': 7.20.13
       classnames: 2.3.2
       dom-helpers: 3.4.0
       invariant: 2.2.4
@@ -10811,10 +10431,8 @@ packages:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
     dev: false
 
-  /react-focus-lock/2.5.2_kzbn2opkn2327fwg5yzwzya5o4:
+  /react-focus-lock/2.5.2_@types+react@18.0.26:
     resolution: {integrity: sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
     peerDependenciesMeta:
       react:
         optional: true
@@ -10889,8 +10507,6 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
     peerDependenciesMeta:
-      '@types/react':
-        optional: true
       react:
         optional: true
     dependencies:
@@ -11033,11 +10649,9 @@ packages:
       warning: 3.0.0
     dev: false
 
-  /react-reconciler/0.27.0_react@18.2.0:
+  /react-reconciler/0.27.0:
     resolution: {integrity: sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==}
     engines: {node: '>=0.10.0'}
-    peerDependencies:
-      react: ^18.0.0
     peerDependenciesMeta:
       react:
         optional: true
@@ -11192,7 +10806,7 @@ packages:
       - zdog
     dev: false
 
-  /react-stripe-js/1.1.2_biqbaboplfbrettd7655fr4n2y:
+  /react-stripe-js/1.1.2_react@18.2.0:
     resolution: {integrity: sha512-ovMKYhMA+k9o7SKvj56XTUpSD5DenB/LlLfqTwqnxXN1hfVfOcNAfnCH9pBLKBq98bfdSXNavyqv6ky5vqToMQ==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -11201,11 +10815,9 @@ packages:
       react:
         optional: true
     dependencies:
-      '@stripe/react-stripe-js': 1.7.2_dg7sxx6zmh46madajf2p7xt5xa
+      '@stripe/react-stripe-js': 1.7.2_@stripe+stripe-js@1.29.0
       '@stripe/stripe-js': 1.29.0
       react: 18.2.0
-    transitivePeerDependencies:
-      - react-dom
     dev: false
 
   /react-transition-group/2.9.0_biqbaboplfbrettd7655fr4n2y:
@@ -11269,21 +10881,16 @@ packages:
       loose-envify: 1.4.0
     dev: false
 
-  /reactour/1.19.0_id224sjdtybtv2oolemsd5viba:
+  /reactour/1.19.0_oey2skiwbnon6xiwiangfbg2je:
     resolution: {integrity: sha512-KHWX46yRXgQX1iD+cS/qI33VYH5jFgZeRxXIk4yJyIAGsTrDTwPeFFa6m7Pv+WX/CoEfggGfdSi2LPAkkuOkOg==}
     peerDependencies:
       react: ^16.3.0 || ^17.0.0-0 || ^18.0.0-0
       react-dom: ^16.3.0 || ^17.0.0-0 || ^18.0.0-0
       react-is: ^16.8 || ^17.0.0-0 || ^18.0.0-0
-      styled-components: ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
       react:
         optional: true
       react-dom:
-        optional: true
-      react-is:
-        optional: true
-      styled-components:
         optional: true
     dependencies:
       '@rooks/use-mutation-observer': 4.11.2_react@18.2.0
@@ -11294,7 +10901,7 @@ packages:
       prop-types: 15.7.2
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-focus-lock: 2.5.2_kzbn2opkn2327fwg5yzwzya5o4
+      react-focus-lock: 2.5.2_@types+react@18.0.26
       react-is: 17.0.2
       scroll-smooth: 1.1.1
       scrollparent: 2.0.1
@@ -11375,9 +10982,6 @@ packages:
     resolution: {integrity: sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==}
     peerDependencies:
       redux: ^4
-    peerDependenciesMeta:
-      redux:
-        optional: true
     dependencies:
       redux: 4.2.0
     dev: false
@@ -11602,9 +11206,6 @@ packages:
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
     peerDependencies:
       rollup: ^2.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
     dependencies:
       '@babel/code-frame': 7.18.6
       jest-worker: 26.6.2
@@ -12232,8 +11833,6 @@ packages:
         optional: true
       react-dom:
         optional: true
-      react-is:
-        optional: true
     dependencies:
       '@babel/helper-module-imports': 7.18.6
       '@babel/traverse': 7.18.13_supports-color@5.5.0
@@ -12254,9 +11853,6 @@ packages:
     resolution: {integrity: sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==}
     peerDependencies:
       stylelint: ^14.10.0
-    peerDependenciesMeta:
-      stylelint:
-        optional: true
     dependencies:
       stylelint: 14.16.1
     dev: true
@@ -12265,9 +11861,6 @@ packages:
     resolution: {integrity: sha512-uy8tZLbfq6ZrXy4JKu3W+7lYLgRQBxYTUUB88vPgQ+ZzAxdrvcaSUW9hOMNLYBnwH+9Kkj19M2DHdZ4gKwI7tg==}
     peerDependencies:
       stylelint: ^14.14.0
-    peerDependenciesMeta:
-      stylelint:
-        optional: true
     dependencies:
       stylelint: 14.16.1
       stylelint-config-recommended: 9.0.0_stylelint@14.16.1
@@ -12464,9 +12057,6 @@ packages:
     resolution: {integrity: sha512-vi9X78CoEz1VVfkKRpUZQa34SEc0QGDd9Hmyis0aeBRAmjp4BpHQ2URcirBsOvFMNBXqB9Klp8sQ9NCRsUEW0w==}
     peerDependencies:
       three: '>= 0.123.0'
-    peerDependenciesMeta:
-      three:
-        optional: true
     dependencies:
       three: 0.148.0
     dev: false
@@ -12475,9 +12065,6 @@ packages:
     resolution: {integrity: sha512-PzlbMFVApPjdFwNoTCnrH6r8J1rQw5Dn40qkHc8P+vVDj1czHOmCduYAA27bYwNNTcd+q3AWE+qutDrvvc5B2g==}
     peerDependencies:
       three: '>=0.122.0'
-    peerDependenciesMeta:
-      three:
-        optional: true
     dependencies:
       '@babel/runtime': 7.20.7
       '@types/offscreencanvas': 2019.7.0
@@ -12623,9 +12210,6 @@ packages:
     resolution: {integrity: sha512-/fPRUmxCkXxyUT8k6REC/aWeFzKbNr37ivrkrplSJNb3JcBUXvVt8MT0Ac5wTUvFsYTviYWprYS4/8Laen08WA==}
     peerDependencies:
       three: '>=0.125.0'
-    peerDependenciesMeta:
-      three:
-        optional: true
     dependencies:
       bidi-js: 1.0.2
       three: 0.148.0
@@ -12638,9 +12222,6 @@ packages:
     resolution: {integrity: sha512-yoVTQxVbpQX3a55giIwqwq6hyJA6oYvq7kaNGwFTeicoWmTZCqqTbytafx1gcuL5umrtw5MYgsxYUSOha+xp5w==}
     peerDependencies:
       three: '>=0.125.0'
-    peerDependenciesMeta:
-      three:
-        optional: true
     dependencies:
       three: 0.148.0
     dev: false
@@ -12670,10 +12251,6 @@ packages:
       '@swc/core':
         optional: true
       '@swc/wasm':
-        optional: true
-      '@types/node':
-        optional: true
-      typescript:
         optional: true
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -12955,9 +12532,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-    peerDependenciesMeta:
-      browserslist:
-        optional: true
     dependencies:
       browserslist: 4.21.4
       escalade: 3.1.1
@@ -13004,10 +12578,8 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /use-memo-one/1.1.2_react@18.2.0:
+  /use-memo-one/1.1.2:
     resolution: {integrity: sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
     peerDependenciesMeta:
       react:
         optional: true
@@ -13621,13 +13193,6 @@ packages:
     resolution: {integrity: sha512-5zx7yhQ8RTLwV71+GA9YsQQ63ALKG8XXIMqRJDdZkR8ZYftFcRgnzM7wOWmQZ/DATspyhPih5wCdcZnAIsM+mA==}
     peerDependencies:
       vite: ^3.1.0 || ^4.0.0
-    peerDependenciesMeta:
-      vite:
-        optional: true
-      workbox-build:
-        optional: true
-      workbox-window:
-        optional: true
     dependencies:
       '@rollup/plugin-replace': 5.0.2_rollup@3.10.0
       debug: 4.3.4


### PR DESCRIPTION
## Description
- Updates recent dependencies flagged by dependabot (except react-bootstrap and @aws-amplify/auth as those are breaking changes)

## Relates to
- #425, #422, #421
