### PR TITLE
Refactor CreateSprintTemplate for easier unit testing and add basic tests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -542,7 +542,7 @@ function App(props: AppProps) {
     sanitySchemas,
     coaches,
     reviewMode: false,
-    navigate: useNavigate()
+    navigate: useNavigate
   };
   languageProps.language = userData.chosenLanguage;
   languageProps.setLanguage = updateLanguage;
@@ -627,7 +627,7 @@ function App(props: AppProps) {
                 <Dialog
                   open={loading}
                   TransitionComponent={
-                    Transition as React.JSXElementConstructor<any> | undefined
+                    Transition as React.JSXElementConstructor<object> | undefined
                   }
                   keepMounted
                   disableEscapeKeyDown

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -570,12 +570,12 @@ function App(props: AppProps) {
                     role="button"
                     style={{
                       filter: theme.palette.mode === "dark" ? "invert()" : "",
-                      height: "20px"
                     }}
                     onClick={handleLogout}
                     onKeyDown={handleLogout}
+                    tabIndex={1}
                   >
-                    <GrLogout />
+                    <GrLogout size={20} />
                   </div>
 
                   <div className="root-padding">
@@ -586,18 +586,21 @@ function App(props: AppProps) {
                   </div>
                   <Palette {...props} />
                   <div className="sticky-nav">
-                    <div className="sticky-chat">
+                    <div
+                      className="sticky-chat"
+                      role="button"
+                      onClick={(event) => {
+                        event.preventDefault();
+                        setIsTourOpen(true);
+                      }}
+                      onKeyDown={(event) => {
+                        event.preventDefault();
+                        setIsTourOpen(true);
+                      }}
+                      tabIndex={0}
+                    >
                       <img
                         src={question}
-                        role="button"
-                        onClick={(event) => {
-                          event.preventDefault();
-                          setIsTourOpen(true);
-                        }}
-                        onKeyDown={(event) => {
-                          event.preventDefault();
-                          setIsTourOpen(true);
-                        }}
                         alt="Home page tour icon"
                         height="24"
                         width="24"

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,15 +1,16 @@
 import { lazy, Suspense } from "react";
-import { Route, RouteProps, Routes, useNavigate } from "react-router-dom";
+import { PathRouteProps, Route, Routes, useNavigate } from "react-router-dom";
 import Spinner from "./components/Spinner";
-import AppliedRoute from "./components/AppliedRoute";
 import AuthenticatedRoute from "./components/AuthenticatedRoute";
 import UnauthenticatedRoute from "./components/UnauthenticatedRoute";
 import { Sprint as SprintInterface } from "./types/ArenaTypes";
 import { User } from "./types/ProfileTypes";
-import ExperienceSummary from "./learn/ExperienceSummary";
 import { Coach } from "./types/MentorshipTypes";
 import Logout from "./components/Logout";
 import MenteeProfile from "./mentorship/MenteeProfile";
+import { getSprintTemplateOptionsFromSanity, getSprintTemplates, setSprintTemplate } from "./utils/queries/createSprintTemplateQueries";
+import { CreateSprintTemplateProps } from "./arena/CreateSprintTemplate";
+import { BrowserHistory } from "history";
 
 const Home = lazy(() => import("./containers/Home"));
 const Login = lazy(() => import("./profile/Login"));
@@ -39,8 +40,7 @@ const MentorDashboard = lazy(() => import("./mentorship/MentorDashboard"));
 
 
 export interface ChildProps {
-  stripeKey: string;
-  navigate: ReturnType<typeof useNavigate>;
+  navigate: ReturnType<typeof useNavigate>
   reviewMode: boolean;
   isAuthenticated: boolean;
   userHasAuthenticated: (b: boolean) => void;
@@ -69,202 +69,216 @@ export interface ChildProps {
   coaches: Coach[];
 }
 
-export interface RouteWithChildProps extends RouteProps {
-  childProps: ChildProps;
-  history: Array<string>;
+interface OrderProps extends ChildProps {
+  stripeKey: string
 }
 
-export default ({ childProps, history, ...rest }: RouteWithChildProps) => (
-  <Suspense fallback={<Spinner />}>
-    <Routes>
-      <Route path="/" {...rest} element={<Home {...childProps} />} />
-      <Route path="/order" {...rest} element={<Order {...childProps} />} />
-      <Route
-        path="/login"
-        {...rest}
-        element={
-          <UnauthenticatedRoute>
-            <Login {...childProps} />
-          </UnauthenticatedRoute>
-        }
-      />
-      <Route
-        path="/login/reset"
-        {...rest}
-        element={
-          <UnauthenticatedRoute>
-            <ResetPassword {...childProps} />
-          </UnauthenticatedRoute>
-        }
-      />
-      <Route
-        path="/signup"
-        {...rest}
-        element={
-          <UnauthenticatedRoute>
-            <Signup {...childProps} />
-          </UnauthenticatedRoute>
-        }
-      />
-      <Route
-        path="/context-builder"
-        {...rest}
-        element={<ContextBuilder {...childProps} />}
-      />
-      <Route
-        path="/context/:id"
-        {...rest}
-        element={<ContextPage {...childProps} />}
-      />
-      <Route
-        path="/hubs/:id"
-        {...rest}
-        element={<ContextPage {...childProps} />}
-      />
-      <Route
-        path="/journal"
-        {...rest}
-        element={
-          <AuthenticatedRoute>
-            <Journal {...childProps} />
-          </AuthenticatedRoute>
-        }
-      // props={childProps}
-      />
-      <Route
-        path="/arena"
-        {...rest}
-        element={
-          <AuthenticatedRoute>
-            <ArenaDashboard {...childProps} />
-          </AuthenticatedRoute>
-        }
-      />
-      <Route
-        path="/arena/create/sprints"
-        {...rest}
-        element={
-          <AuthenticatedRoute>
-            <SprintCreation {...childProps} />
-          </AuthenticatedRoute>
-        }
-      />
-      <Route
-        path="/arena/create/template"
-        {...rest}
-        element={
-          <AuthenticatedRoute>
-            <CreateSprintTemplate {...childProps} />
-          </AuthenticatedRoute>
-        }
-      />
-      <Route
-        path="/arena/sprints/:id"
-        {...rest}
-        element={
-          <AuthenticatedRoute>
-            <Sprint {...childProps} />
-          </AuthenticatedRoute>
-        }
-      />
-      <Route
-        path="/training"
-        {...rest}
-        element={
-          <AuthenticatedRoute>
-            <LearnDashboard {...childProps} />
-          </AuthenticatedRoute>
-        }
-      />
-      <Route
-        path="/training/:id"
-        {...rest}
-        element={
-          <AuthenticatedRoute>
-            <ExperienceModule {...childProps} history={history} />
-          </AuthenticatedRoute>
-        }
-      />
-      <Route
-        path="/chat/:id"
-        {...rest}
-        /* @ts-ignore */
-        element={<Room {...childProps} />}
-      // props={childProps}
-      />
-      <Route
-        path="/settings/password"
-        {...rest}
-        element={
-          <AuthenticatedRoute>
-            <ChangePassword {...childProps} />
-          </AuthenticatedRoute>
-        }
-      />
-      <Route
-        path="/profile/:id"
-        {...rest}
-        element={
-          <AuthenticatedRoute>
-            <Profile />
-          </AuthenticatedRoute>
-        }
-      />
-      <Route
-        path="/profile/edit/:id"
-        {...rest}
-        element={
-          <AuthenticatedRoute>
-            <EditProfile {...childProps} />
-          </AuthenticatedRoute>
-        }
-      />
-      <Route
-        path="/profile/languages/:id"
-        {...rest}
-        element={
-          <AuthenticatedRoute>
-            <LanguageSelector {...childProps} />
-          </AuthenticatedRoute>
-        }
-      />
-      <Route
-        path="/onboarding/user"
-        {...rest}
-        element={<CreateUser {...childProps} />}
-      />
-      <Route
-        path="/sandbox"
-        {...rest}
-        element={
-          <AuthenticatedRoute>
-            <Sandbox {...childProps} />
-          </AuthenticatedRoute>
-        }
-      />
-      <Route
-        path="/mentorship"
-        {...rest}
-        element={
-          <AuthenticatedRoute>
-            <MentorDashboard {...childProps} />
-          </AuthenticatedRoute>
-        }
-      />
-      <Route
-        path="/mentorship/:id"
-        {...rest}
-        element={
-          <AuthenticatedRoute>
-            <MenteeProfile {...childProps} />
-          </AuthenticatedRoute>
-        }
-      />
-      <Route path="/logout" {...rest} element={<Logout />} />
+export interface RouteWithChildProps extends PathRouteProps {
+  childProps: ChildProps | CreateSprintTemplateProps | OrderProps;
+  history: BrowserHistory;
+}
 
-      <Route path="/workandrise" {...rest} element={<WorkRise />} />
-      {/* Finally, catch all unmatched routes */}
-      <Route path="/*" element={<NotFound />} />
-    </Routes>
-  </Suspense>
-);
+function RoutesComponent({ childProps, history, ...rest }: RouteWithChildProps) {
+  return (
+    <Suspense fallback={<Spinner />}>
+      <Routes>
+        <Route path="/" {...rest} element={<Home {...childProps} />} />
+        <Route path="/order" {...rest} element={<Order {...childProps as OrderProps} />} />
+        <Route
+          path="/login"
+          {...rest}
+          element={
+            <UnauthenticatedRoute>
+              <Login {...childProps as ChildProps} />
+            </UnauthenticatedRoute>
+          }
+        />
+        <Route
+          path="/login/reset"
+          {...rest}
+          element={
+            <UnauthenticatedRoute>
+              <ResetPassword {...childProps as ChildProps} />
+            </UnauthenticatedRoute>
+          }
+        />
+        <Route
+          path="/signup"
+          {...rest}
+          element={
+            <UnauthenticatedRoute>
+              <Signup {...childProps} />
+            </UnauthenticatedRoute>
+          }
+        />
+        <Route
+          path="/context-builder"
+          {...rest}
+          element={<ContextBuilder {...childProps} />}
+        />
+        <Route
+          path="/context/:id"
+          {...rest}
+          element={<ContextPage {...childProps} />}
+        />
+        <Route
+          path="/hubs/:id"
+          {...rest}
+          element={<ContextPage {...childProps} />}
+        />
+        <Route
+          path="/journal"
+          {...rest}
+          element={
+            <AuthenticatedRoute>
+              <Journal {...childProps as ChildProps} />
+            </AuthenticatedRoute>
+          }
+        // props={childProps}
+        />
+        <Route
+          path="/arena"
+          {...rest}
+          element={
+            <AuthenticatedRoute>
+              <ArenaDashboard {...childProps as ChildProps} />
+            </AuthenticatedRoute>
+          }
+        />
+        <Route
+          path="/arena/create/sprints"
+          {...rest}
+          element={
+            <AuthenticatedRoute>
+              <SprintCreation {...childProps as ChildProps} />
+            </AuthenticatedRoute>
+          }
+        />
+        <Route
+          path="/arena/create/template"
+          {...rest}
+          element={
+            <AuthenticatedRoute>
+              <CreateSprintTemplate {...{
+                ...childProps,
+                navigate: useNavigate,
+                getTemplates: getSprintTemplates,
+                setTemplate: setSprintTemplate,
+                getTemplateOptionsFromSanity: getSprintTemplateOptionsFromSanity
+              }} />
+            </AuthenticatedRoute>
+          }
+        />
+        <Route
+          path="/arena/sprints/:id"
+          {...rest}
+          element={
+            <AuthenticatedRoute>
+              <Sprint {...childProps as ChildProps} />
+            </AuthenticatedRoute>
+          }
+        />
+        <Route
+          path="/training"
+          {...rest}
+          element={
+            <AuthenticatedRoute>
+              <LearnDashboard {...childProps} />
+            </AuthenticatedRoute>
+          }
+        />
+        <Route
+          path="/training/:id"
+          {...rest}
+          element={
+            <AuthenticatedRoute>
+              <ExperienceModule {...childProps} history={history} />
+            </AuthenticatedRoute>
+          }
+        />
+        <Route
+          path="/chat/:id"
+          {...rest}
+          /* @ts-ignore */
+          element={<Room {...childProps} />}
+        // props={childProps}
+        />
+        <Route
+          path="/settings/password"
+          {...rest}
+          element={
+            <AuthenticatedRoute>
+              <ChangePassword />
+            </AuthenticatedRoute>
+          }
+        />
+        <Route
+          path="/profile/:id"
+          {...rest}
+          element={
+            <AuthenticatedRoute>
+              <Profile />
+            </AuthenticatedRoute>
+          }
+        />
+        <Route
+          path="/profile/edit/:id"
+          {...rest}
+          element={
+            <AuthenticatedRoute>
+              <EditProfile {...childProps} />
+            </AuthenticatedRoute>
+          }
+        />
+        <Route
+          path="/profile/languages/:id"
+          {...rest}
+          element={
+            <AuthenticatedRoute>
+              <LanguageSelector {...childProps as ChildProps} />
+            </AuthenticatedRoute>
+          }
+        />
+        <Route
+          path="/onboarding/user"
+          {...rest}
+          element={<CreateUser {...childProps as ChildProps} />}
+        />
+        <Route
+          path="/sandbox"
+          {...rest}
+          element={
+            <AuthenticatedRoute>
+              <Sandbox />
+            </AuthenticatedRoute>
+          }
+        />
+        <Route
+          path="/mentorship"
+          {...rest}
+          element={
+            <AuthenticatedRoute>
+              <MentorDashboard {...childProps} />
+            </AuthenticatedRoute>
+          }
+        />
+        <Route
+          path="/mentorship/:id"
+          {...rest}
+          element={
+            <AuthenticatedRoute>
+              <MenteeProfile {...childProps} />
+            </AuthenticatedRoute>
+          }
+        />
+        <Route path="/logout" {...rest} element={<Logout />} />
+
+        <Route path="/workandrise" {...rest} element={<WorkRise />} />
+        {/* Finally, catch all unmatched routes */}
+        <Route path="/*" element={<NotFound />} />
+      </Routes>
+    </Suspense>
+  )
+};
+
+export default RoutesComponent

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from "react";
-import { PathRouteProps, Route, Routes, useNavigate } from "react-router-dom";
+import { NavigateFunction, PathRouteProps, Route, Routes, useNavigate } from "react-router-dom";
 import Spinner from "./components/Spinner";
 import AuthenticatedRoute from "./components/AuthenticatedRoute";
 import UnauthenticatedRoute from "./components/UnauthenticatedRoute";
@@ -40,7 +40,7 @@ const MentorDashboard = lazy(() => import("./mentorship/MentorDashboard"));
 
 
 export interface ChildProps {
-  navigate: ReturnType<typeof useNavigate>
+  navigate: NavigateFunction
   reviewMode: boolean;
   isAuthenticated: boolean;
   userHasAuthenticated: (b: boolean) => void;
@@ -199,9 +199,7 @@ function RoutesComponent({ childProps, history, ...rest }: RouteWithChildProps) 
         <Route
           path="/chat/:id"
           {...rest}
-          /* @ts-ignore */
-          element={<Room {...childProps} />}
-        // props={childProps}
+          element={<Room />}
         />
         <Route
           path="/settings/password"

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -57,8 +57,8 @@ export interface ChildProps {
   sanityInterview: {};
   sanityProduct: {};
   experiences: {};
-  fetchMenteeSprints: (id: string) => void;
-  initialFetch: (id: string) => void;
+  fetchMenteeSprints: (id: string) => Promise<void>;
+  initialFetch: (id: string) => Promise<void>;
   sprints: SprintInterface[];
   athletes: any[];
   sanitySchemas: {

--- a/src/arena/CreateSprintTemplate.tsx
+++ b/src/arena/CreateSprintTemplate.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useContext, SetStateAction } from "react";
-import ControlLabel from "react-bootstrap/lib/ControlLabel";
-import { useTheme, Button } from "@mui/material";
+import { useTheme, Button, FormLabel } from "@mui/material";
 import { ToastMsgContext } from "../state/ToastContext";
 import TextField from "@mui/material/TextField";
 import {
@@ -218,40 +217,37 @@ function CreateSprintTemplate(props: CreateSprintTemplateProps) {
           flexDirection: "row",
         }}
       >
-        <div style={{ margin: 'auto 25px auto 0px' }}>
-          <ControlLabel >
-            {I18n.get("enterTemplateName")}
-          </ControlLabel>
-        </div>
-        <div style={{ width: 300, margin:'auto 0px' }}>
-          <TextField
-            color="success"
-            error={!!error}
-            required
-            helperText={error}
-            fullWidth
-            label={I18n.get("templateName")}
-            variant="outlined"
-            value={title}
-            onChange={(event) => setTitle(event.target.value)}
-          />
-        </div>
-        <div style={{ margin: 'auto 0px auto 30px' }}>
-          <Button
-            disabled={
-              (title === "" && meetsMinimumOptionsThreshold === false) || !!error
-            }
-            fullWidth
-            size="large"
-            variant="gradient"
-            sx={{
-              height: "3.8rem" 
-            }}
-            onClick={createTemplate}
-          >
-            {I18n.get("create")}
-          </Button>
-        </div>
+        <FormLabel sx={{ margin: 'auto 25px auto 0px' }} >
+          {I18n.get("enterTemplateName")}
+        </FormLabel>
+        <TextField
+          color="success"
+          error={!!error}
+          required
+          helperText={error}
+          fullWidth
+          label={I18n.get("templateName")}
+          variant="outlined"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          sx={{ width: '300px', minWidth: '300px', margin:'auto 0px' }}
+        />
+        <Button
+          disabled={
+            (title === "" && meetsMinimumOptionsThreshold === false) || !!error
+          }
+          fullWidth
+          size="large"
+          variant="gradient"
+          sx={{
+            height: "3.8rem",
+            margin: 'auto 0px auto 30px',
+            maxWidth: '280px'
+          }}
+          onClick={createTemplate}
+        >
+          {I18n.get("create")}
+        </Button>
       </div>
       <h2
         style={{

--- a/src/arena/CreateSprintTemplate.tsx
+++ b/src/arena/CreateSprintTemplate.tsx
@@ -11,7 +11,7 @@ import {
 } from "react-beautiful-dnd";
 import { nanoid } from "nanoid";
 import { I18n } from "@aws-amplify/core";
-import { useNavigate } from "react-router-dom";
+import { NavigateFunction, useNavigate } from "react-router-dom";
 
 /**
  *
@@ -21,7 +21,7 @@ import { useNavigate } from "react-router-dom";
 
 export interface CreateSprintTemplateProps {
   user: { fName: string; lName: string; id: number };
-  navigate: ReturnType<typeof useNavigate>;
+  navigate: typeof useNavigate;
   getTemplates: () => Promise<Array<{ title: string}>>;
   setTemplate: (body: object) => Promise<void>;
   getTemplateOptionsFromSanity: () => Promise<object>;
@@ -91,7 +91,7 @@ function CreateSprintTemplate(props: CreateSprintTemplateProps) {
   const { handleShowError, handleShowSuccess } = useContext(ToastMsgContext);
 
   const theme = useTheme();
-  const navigate = props.navigate;
+  const navigate = props.navigate();
 
   const [columns, setColumns] = useState({
     Options: {
@@ -238,7 +238,6 @@ function CreateSprintTemplate(props: CreateSprintTemplateProps) {
         </div>
         <div style={{ margin: 'auto 0px auto 30px' }}>
           <Button
-            /* @ts-ignore */
             disabled={
               (title === "" && meetsMinimumOptionsThreshold === false) || !!error
             }

--- a/src/arena/CreateSprintTemplate.tsx
+++ b/src/arena/CreateSprintTemplate.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState, useContext } from "react";
-import FormGroup from "react-bootstrap/lib/FormGroup";
+import React, { useEffect, useState, useContext, SetStateAction } from "react";
 import ControlLabel from "react-bootstrap/lib/ControlLabel";
 import { useTheme, Button } from "@mui/material";
 import { ToastMsgContext } from "../state/ToastContext";
@@ -11,9 +10,7 @@ import {
   DropResult,
 } from "react-beautiful-dnd";
 import { nanoid } from "nanoid";
-import { RestAPI } from "@aws-amplify/api-rest";
 import { I18n } from "@aws-amplify/core";
-import sanity from "../libs/sanity";
 import { useNavigate } from "react-router-dom";
 
 /**
@@ -22,9 +19,12 @@ import { useNavigate } from "react-router-dom";
  * @TODO This page needs a few improvements.
  */
 
-interface CreateSprintTemplateProps {
+export interface CreateSprintTemplateProps {
   user: { fName: string; lName: string; id: number };
   navigate: ReturnType<typeof useNavigate>;
+  getTemplates: () => Promise<Array<{ title: string}>>;
+  setTemplate: (body: object) => Promise<void>;
+  getTemplateOptionsFromSanity: () => Promise<object>;
 }
 
 interface OnDragEndParams {
@@ -91,7 +91,7 @@ function CreateSprintTemplate(props: CreateSprintTemplateProps) {
   const { handleShowError, handleShowSuccess } = useContext(ToastMsgContext);
 
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = props.navigate;
 
   const [columns, setColumns] = useState({
     Options: {
@@ -112,19 +112,19 @@ function CreateSprintTemplate(props: CreateSprintTemplateProps) {
     },
   });
   const [title, setTitle] = useState("");
-  const [existingTemplates, setExistingTemplates] = useState([]);
+  const [existingTemplates, setExistingTemplates] = useState([] as string[]);
   const [error, setError] = useState("");
 
   async function createTemplate() {
     let missionsArray: never[] = [];
 
-    columns.Morning.items.map((item) => {
+    columns.Morning.items.forEach((item) => {
       missionsArray.push(item);
     });
-    columns.Workday.items.map((item) => {
+    columns.Workday.items.forEach((item) => {
       missionsArray.push(item);
     });
-    columns.Evening.items.map((item) => {
+    columns.Evening.items.forEach((item) => {
       missionsArray.push(item);
     });
 
@@ -143,42 +143,15 @@ function CreateSprintTemplate(props: CreateSprintTemplateProps) {
       createdAt: Date.now(),
     };
     try {
-      await RestAPI.post("pareto", `/templates`, { body });
+      await props.setTemplate(body)
       navigate("/");
     } catch (e) {
       handleShowError(e as Error);
     }
   }
 
-  /**
-   * Getting our potential sprint items from Sanity. Will likely need to replace later.
-   */
-  async function getSanityItems() {
-    const query = `*[_type == 'achievement' && !(_id in path("drafts.**"))]`;
-    const links = await sanity.fetch(query);
-    let initialData = {
-      Options: {
-        name: `${I18n.get("options")}`,
-        items: links,
-      },
-      Morning: {
-        name: `${I18n.get("morning")}`,
-        items: [],
-      },
-      Workday: {
-        name: `${I18n.get("workday")}`,
-        items: [],
-      },
-      Evening: {
-        name: `${I18n.get("evening")}`,
-        items: [],
-      },
-    };
-    setColumns(initialData);
-  }
-
   useEffect(() => {
-    getSanityItems();
+    props.getTemplateOptionsFromSanity().then((res) => setColumns(res as SetStateAction<{ Options: { name: string; items: never[]; }; Morning: { name: string; items: never[]; }; Workday: { name: string; items: never[]; }; Evening: { name: string; items: never[]; }; }>))
   }, []);
 
   useEffect(() => {
@@ -187,8 +160,9 @@ function CreateSprintTemplate(props: CreateSprintTemplateProps) {
 
   // pulls the /templates api and sets the existing templates
   async function getConfiguration() {
-    let options = await RestAPI.get("pareto", "/templates", {});
-    setExistingTemplates(options.map((option: { title: any }) => option.title));
+    const templates = await props.getTemplates();
+    const templateTitles: string[] = templates.map((option: { title: string }) => option.title);
+    setExistingTemplates(templateTitles);
   }
   // This will equal true or false, not a number
   const meetsMinimumOptionsThreshold =
@@ -237,41 +211,49 @@ function CreateSprintTemplate(props: CreateSprintTemplateProps) {
       >
         {I18n.get("createTemplate")}
       </h1>
-      <FormGroup
-        controlId="fName"
-        bsSize="large"
+      <div
         style={{
           width: "auto",
           display: "flex",
           flexDirection: "row",
         }}
       >
-        <ControlLabel style={{ marginRight: 25, paddingTop: 10 }}>
-          {I18n.get("enterTemplateName")}
-        </ControlLabel>
-        <TextField
-          color="success"
-          error={!!error}
-          required
-          helperText={error}
-          style={{ width: 300 }}
-          label={I18n.get("templateName")}
-          variant="outlined"
-          value={title}
-          onChange={(event) => setTitle(event.target.value)}
-        />
-        <Button
-          /* @ts-ignore */
-          disabled={
-            (title === "" && meetsMinimumOptionsThreshold === false) || !!error
-          }
-          variant="gradient"
-          onClick={createTemplate}
-          style={{ marginLeft: 30, height: "4.8rem" }}
-        >
-          {I18n.get("create")}
-        </Button>
-      </FormGroup>
+        <div style={{ margin: 'auto 25px auto 0px' }}>
+          <ControlLabel >
+            {I18n.get("enterTemplateName")}
+          </ControlLabel>
+        </div>
+        <div style={{ width: 300, margin:'auto 0px' }}>
+          <TextField
+            color="success"
+            error={!!error}
+            required
+            helperText={error}
+            fullWidth
+            label={I18n.get("templateName")}
+            variant="outlined"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+          />
+        </div>
+        <div style={{ margin: 'auto 0px auto 30px' }}>
+          <Button
+            /* @ts-ignore */
+            disabled={
+              (title === "" && meetsMinimumOptionsThreshold === false) || !!error
+            }
+            fullWidth
+            size="large"
+            variant="gradient"
+            sx={{
+              height: "3.8rem" 
+            }}
+            onClick={createTemplate}
+          >
+            {I18n.get("create")}
+          </Button>
+        </div>
+      </div>
       <h2
         style={{
           marginTop: 50,

--- a/src/arena/CreateSprintTemplate.tsx
+++ b/src/arena/CreateSprintTemplate.tsx
@@ -11,7 +11,7 @@ import {
 } from "react-beautiful-dnd";
 import { nanoid } from "nanoid";
 import { I18n } from "@aws-amplify/core";
-import { NavigateFunction, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 /**
  *

--- a/src/components/AuthenticatedLayout.tsx
+++ b/src/components/AuthenticatedLayout.tsx
@@ -1,0 +1,99 @@
+import { useTheme } from "@mui/material";
+import { EventHandler, SyntheticEvent } from "react";
+import { GrLogout } from "react-icons/gr";
+import Palette from "../containers/Palette";
+import LeftNav from "./LeftNav";
+import ErrorBoundary from "./ErrorBoundary";
+import Routes, { ChildProps } from "../Routes";
+import MusicPlayer from "./MusicPlayer";
+import BottomNav from "./BottomNav";
+import { BrowserHistory } from "history";
+import question from "../assets/help.png";
+
+interface AuthenticatedLayoutProps {
+  handleLogout: EventHandler<SyntheticEvent>;
+  customHistory: BrowserHistory;
+  childProps: ChildProps;
+  setIsTourOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export default function AuthenticatedLayout(props: AuthenticatedLayoutProps)
+ {
+  const { handleLogout, customHistory, childProps, setIsTourOpen } = props
+  const { user, athletes } = childProps;
+  const theme = useTheme();
+
+  return (
+    <>
+      <Palette />
+      <LogoutButton handleLogout={handleLogout} mode={theme.palette.mode} />
+      <div className="root-padding">
+        <LeftNav user={user} athletes={athletes} />
+        <RoutesWithErrorBoundary customHistory={customHistory} childProps={childProps} />
+      </div>
+      <div className="sticky-nav">
+        <TourButton setIsTourOpen={setIsTourOpen} />
+        <MusicPlayer />
+        <BottomNav user={user} />
+      </div>
+    </>
+  )
+}
+
+function RoutesWithErrorBoundary({ customHistory, childProps }: { customHistory: BrowserHistory, childProps: ChildProps }) {
+  return (
+    <ErrorBoundary history={customHistory}>
+      <Routes history={customHistory} childProps={childProps} />
+    </ErrorBoundary>
+  )
+}
+
+function TourButton({ setIsTourOpen }: { setIsTourOpen: React.Dispatch<React.SetStateAction<boolean>> }) {
+  return (
+    <div
+      className="sticky-chat"
+      role="button"
+      onClick={(event) => {
+        event.preventDefault();
+        setIsTourOpen(true);
+      }}
+      onKeyDown={(event) => {
+        event.preventDefault();
+        setIsTourOpen(true);
+      }}
+      tabIndex={0}
+    >
+      <img
+        src={question}
+        alt="Home page tour icon"
+        height="24"
+        width="24"
+        className="sticky-btn"
+        style={{
+          cursor: "pointer",
+          filter: "grayscale(100%)",
+          outline: "2px solid white",
+          border: "2px solid transparent",
+          borderRadius: "50%",
+        }}
+      />
+    </div>
+  )
+}
+
+function LogoutButton({ mode, handleLogout }: { mode: string, handleLogout: EventHandler<SyntheticEvent> }) {
+  return (
+    <div
+      className="sticky-logout"
+      role="button"
+      style={{
+        filter: mode === "dark" ? "invert()" : "",
+      }}
+      onClick={handleLogout}
+      onKeyDown={handleLogout}
+      tabIndex={0}
+    >
+      <GrLogout size={20} />
+    </div>
+  )
+}

--- a/src/components/MusicPlayer.tsx
+++ b/src/components/MusicPlayer.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, MouseEventHandler } from "react";
 import {
   IoMdPlay,
   IoMdPause,
@@ -12,17 +12,18 @@ import FatsNY from "../assets/mp3/FatsNY.mp3";
 import PictureBall from "../assets/mp3/PictureBall.mp3";
 import Silvery from "../assets/mp3/Silvery.mp3";
 import SecretGarden from "../assets/mp3/SecretGarden.mp3";
+import { IconType } from "react-icons/lib";
 
-export default function MusicPlayer(props: any) {
+export interface Song {
+  title: string;
+  artist: string;
+  img_src: IconType;
+  src: string;
+}
+
+export default function MusicPlayer() {
   const [currentSong, setCurrentSong] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
-
-  interface Song {
-    title: string;
-    artist: string;
-    img_src: any;
-    src: string;
-  }
 
   const songs: Song[] = useMemo(
     () => [
@@ -100,43 +101,71 @@ export default function MusicPlayer(props: any) {
   };
 
   return (
-    <div
-      style={{
-        backgroundColor: "gray",
-        display: "flex",
-        justifyContent: "space-between",
-        paddingLeft: 20,
-        paddingTop: 8,
-      }}
-    >
-      <div>
-        <h3>Now Playing</h3>
-        <p>
-          {songs[currentSong].title} by {songs[currentSong].artist}
-        </p>
-      </div>
-
-      <div>
-        <IoMdSkipBackward
-          style={{ cursor: "pointer", margin: 12 }}
-          onClick={handlePrevious}
-        />
-        {isPlaying ? (
-          <IoMdPause
-            style={{ cursor: "pointer", margin: 12 }}
-            onClick={() => (!isPlaying ? handlePlay() : handlePause())}
-          />
-        ) : (
-          <IoMdPlay
-            style={{ cursor: "pointer", margin: 12 }}
-            onClick={() => (!isPlaying ? handlePlay() : handlePause())}
-          />
-        )}
-        <IoMdSkipForward
-          style={{ cursor: "pointer", margin: 12 }}
-          onClick={handleSkip}
+    <div className="sticky-audio">
+      <div
+        style={{
+          backgroundColor: "gray",
+          display: "flex",
+          justifyContent: "space-between",
+          paddingLeft: 20,
+          paddingTop: 8,
+        }}
+      >
+        <NowPlaying songs={songs} currentSong={currentSong} />
+        <MusicPlayerControls
+          isPlaying={isPlaying}
+          handlePrevious={handlePrevious}
+          handlePlay={handlePlay}
+          handlePause={handlePause}
+          handleSkip={handleSkip}
         />
       </div>
     </div>
   );
+}
+
+interface NowPlayingProps {
+  songs: Song[];
+  currentSong: number;
+}
+
+function NowPlaying({ songs, currentSong }: NowPlayingProps) {
+  return (
+    <div>
+      <h3>Now Playing</h3>
+      <p>
+        {songs[currentSong].title} by {songs[currentSong].artist}
+      </p>
+    </div>
+  )
+}
+
+interface MusicPlayerPlayerControlsProps {
+  isPlaying: boolean;
+  handlePrevious: MouseEventHandler;
+  handlePlay: MouseEventHandler;
+  handlePause: MouseEventHandler;
+  handleSkip: MouseEventHandler;
+}
+
+function MusicPlayerControls({ isPlaying, handlePrevious, handlePlay, handlePause, handleSkip }: MusicPlayerPlayerControlsProps) {
+  return (
+    <div style={{ display: 'flex', flexWrap: 'nowrap' }}>
+      <StyledIcon Icon={IoMdSkipBackward} handleClick={handlePrevious}/>
+      {isPlaying ? (
+        <StyledIcon Icon={IoMdPause} handleClick={(e) => (!isPlaying ? handlePlay(e) : handlePause(e))}/>
+      ) : (
+        <StyledIcon Icon={IoMdPlay} handleClick={(e) => (!isPlaying ? handlePlay(e) : handlePause(e))}/>
+      )}
+      <StyledIcon Icon={IoMdSkipForward} handleClick={handleSkip}/>
+    </div>
+  )
+}
+
+function StyledIcon({ Icon, handleClick }: { Icon: IconType, handleClick: MouseEventHandler }) {
+  return (
+    <div style={{ cursor: "pointer", margin: 12 }}>
+      <Icon onClick={handleClick} />
+    </div>
+  )
 }

--- a/src/components/UnauthenticatedLayout.tsx
+++ b/src/components/UnauthenticatedLayout.tsx
@@ -1,0 +1,12 @@
+import { BrowserHistory } from "history";
+import Routes, { ChildProps } from "../Routes";
+
+interface UnauthenticatedLayoutProps {
+  childProps: ChildProps;
+}
+
+export default function UnauthenticatedLayout({ childProps }: UnauthenticatedLayoutProps) {
+  return (
+    <Routes childProps={childProps} history={{} as BrowserHistory} />
+  )
+}

--- a/src/containers/Palette.tsx
+++ b/src/containers/Palette.tsx
@@ -40,7 +40,7 @@ const routes = [
   },
 ];
 
-function CommandPalette(props: any) {
+function CommandPalette() {
   const ninjaKeys = useRef<any>(null);
   const navigate = useNavigate()
 
@@ -112,7 +112,7 @@ function CommandPalette(props: any) {
       {/* @ts-ignore */}
       <ninja-keys ref={ninjaKeys}></ninja-keys>
       <Dialog
-        style={{
+        sx={{
           margin: "auto",
           padding: 12,
         }}
@@ -128,7 +128,7 @@ function CommandPalette(props: any) {
             size="small"
             variant="contained"
             color="primary"
-            style={{
+            sx={{
               padding: "10px",
               fontSize: "20px",
             }}
@@ -145,7 +145,7 @@ function CommandPalette(props: any) {
             size="small"
             variant="contained"
             color="secondary"
-            style={{
+            sx={{
               padding: "10px",
               fontSize: "20px",
             }}

--- a/src/tests/CreateSprintTemplate.spec.tsx
+++ b/src/tests/CreateSprintTemplate.spec.tsx
@@ -7,7 +7,7 @@ import { vi, describe, beforeEach, afterEach, it, expect } from "vitest";
 
 import CreateSprintTemplate from "../arena/CreateSprintTemplate";
 import { getSprintTemplateOptionsFromSanity, getSprintTemplates, setSprintTemplate } from "../utils/queries/createSprintTemplateQueries";
-import { BrowserRouter, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { getSampleTemplates } from "./testData";
 
 

--- a/src/tests/CreateSprintTemplate.spec.tsx
+++ b/src/tests/CreateSprintTemplate.spec.tsx
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { vi, describe, beforeEach, afterEach, it, expect } from "vitest";
+
+import CreateSprintTemplate from "../arena/CreateSprintTemplate";
+import { getSprintTemplateOptionsFromSanity, getSprintTemplates, setSprintTemplate } from "../utils/queries/createSprintTemplateQueries";
+import { useNavigate } from "react-router-dom";
+import { getSampleTemplates } from "./testData";
+
+
+
+describe("CREATE SPRINT TEMPLATE", () => {
+  const testUser = {
+    fName: "Test",
+    lName: "User",
+    id: 12345,
+  };
+  const mockGetTemplates = vi.fn().mockImplementation(getSprintTemplates);
+  const mockSetTemplate = vi.fn().mockImplementation(setSprintTemplate);
+  const mockGetTemplateOptions = vi.fn().mockImplementation(getSprintTemplateOptionsFromSanity);
+  const mockNavigate = vi.fn().mockImplementation(useNavigate);
+
+  describe("Initial view with sprint template creation components", () => {
+    beforeEach(() => {
+      mockGetTemplateOptions.mockResolvedValue({
+        Options: {
+          name: "Options",
+          items:
+            [{
+              "_createdAt": "2021-02-16T16:58:02Z",
+              "_id": "0dba2e60-9c03-429e-aae7-aa9f85429cef",
+              "_rev": "JPiyOitNVV6JvzMfjLRBCv",
+              "_type": "achievement",
+              "_updatedAt": "2021-02-16T16:58:02Z",
+              "summary": "The primary job of the entrepreneur is to get sales, or at the least feedback to determine whether people want what you have.",
+              "title": "Talk to Customers",
+              "type": "productivity",
+              "xp": 100
+            }]
+        },
+        Morning: {
+          name: "Morning",
+          items: []
+        },
+        Workday: {
+          name: "Workday",
+          items: []
+        },
+        Evening: {
+          name: "Evening",
+          items: []
+        },
+      })
+      mockGetTemplates.mockResolvedValue([
+        getSampleTemplates(1)
+      ])
+
+      render(
+        <CreateSprintTemplate
+          user={testUser}
+          navigate={mockNavigate}
+          getTemplates={mockGetTemplates}
+          setTemplate={mockSetTemplate}
+          getTemplateOptionsFromSanity={mockGetTemplateOptions}
+        />
+      );
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+      cleanup()
+    })
+
+    it("displays a title, name form, columns for daily achievements, and a create sprint template button", () => {
+      expect(screen.getByText("createTemplate")).toBeDefined();
+      expect(screen.getByText("enterTemplateName")).toBeDefined();
+      expect(screen.getByText("Options")).toBeDefined();
+      expect(screen.getByText("Morning")).toBeDefined();
+      expect(screen.getByText("Workday")).toBeDefined();
+      expect(screen.getByText("Evening")).toBeDefined();
+      expect(screen.getByText("create")).toBeDefined();
+    });
+
+    it("displays one option in the options column", async () => {
+      await waitFor(() => expect(screen.getByText("productivity")).toBeDefined());
+      const optionsColumnItems = screen.getByText("Options").nextSibling?.childNodes[0].childNodes;
+      expect(optionsColumnItems?.length).toEqual(1);
+    });
+
+    it("displays no options in the other columns", async () => {
+      await waitFor(() => expect(screen.getByText("productivity")).toBeDefined());
+      
+      const morningColumnItems = screen.getByText("Morning").nextSibling?.childNodes[0].childNodes;
+      const workdayColumnItems = screen.getByText("Workday").nextSibling?.childNodes[0].childNodes;
+      const eveningColumnItems = screen.getByText("Evening").nextSibling?.childNodes[0].childNodes;
+
+      expect(morningColumnItems?.length).toEqual(0);
+      expect(workdayColumnItems?.length).toEqual(0);
+      expect(eveningColumnItems?.length).toEqual(0);
+    });
+  });
+});

--- a/src/tests/CreateSprintTemplate.spec.tsx
+++ b/src/tests/CreateSprintTemplate.spec.tsx
@@ -7,7 +7,7 @@ import { vi, describe, beforeEach, afterEach, it, expect } from "vitest";
 
 import CreateSprintTemplate from "../arena/CreateSprintTemplate";
 import { getSprintTemplateOptionsFromSanity, getSprintTemplates, setSprintTemplate } from "../utils/queries/createSprintTemplateQueries";
-import { useNavigate } from "react-router-dom";
+import { BrowserRouter, useNavigate } from "react-router-dom";
 import { getSampleTemplates } from "./testData";
 
 
@@ -22,6 +22,7 @@ describe("CREATE SPRINT TEMPLATE", () => {
   const mockSetTemplate = vi.fn().mockImplementation(setSprintTemplate);
   const mockGetTemplateOptions = vi.fn().mockImplementation(getSprintTemplateOptionsFromSanity);
   const mockNavigate = vi.fn().mockImplementation(useNavigate);
+  mockNavigate.mockReturnValue(vi.fn())
 
   describe("Initial view with sprint template creation components", () => {
     beforeEach(() => {
@@ -59,13 +60,13 @@ describe("CREATE SPRINT TEMPLATE", () => {
       ])
 
       render(
-        <CreateSprintTemplate
-          user={testUser}
-          navigate={mockNavigate}
-          getTemplates={mockGetTemplates}
-          setTemplate={mockSetTemplate}
-          getTemplateOptionsFromSanity={mockGetTemplateOptions}
-        />
+          <CreateSprintTemplate
+            user={testUser}
+            navigate={mockNavigate}
+            getTemplates={mockGetTemplates}
+            setTemplate={mockSetTemplate}
+            getTemplateOptionsFromSanity={mockGetTemplateOptions}
+            />
       );
     });
 

--- a/src/tests/testData.ts
+++ b/src/tests/testData.ts
@@ -1,0 +1,114 @@
+
+interface TemplateConfig {
+  titles?: string[],
+  firstNames?: string[],
+  lastNames?: string[]
+}
+
+export function getSampleTemplates(number: number, config?: TemplateConfig) {
+  if (number === 1) {
+    return [getSampleTemplate()]
+  }
+  const { titles, firstNames, lastNames } = config ? config : { titles: null, firstNames: null, lastNames: null};
+  const results = [...new Array(number).keys()]
+  return results.map((item) => getSampleTemplate(
+    titles && titles.length > 0 ? getRandomArrayEntry(titles) : undefined,
+    firstNames && firstNames.length > 0 && lastNames && lastNames.length > 0 ? 
+      {
+        fName: getRandomArrayEntry(firstNames),
+        lName: getRandomArrayEntry(lastNames),
+        id: parseInt(`12345${item}`)
+      } : undefined
+  ))
+}
+
+function getRandomArrayEntry(array: string[]) {
+  return array[Math.floor(Math.random() * array.length)]
+}
+
+function getSampleTemplate(title?: string, user?: { fName: string, lName: string, id: number}) {
+  return {
+        "admin": {
+            "name": user ? `${user.fName} ${user.lName}` : "Vilfredo Pareto",
+            "adminId": user?.id || 12345
+        },
+        "_id": "63daf2e82cfaad59af962622",
+        "id": "OtdBEbqXMX7-zGdM-Llrr",
+        "title": title || "Simple Sprint",
+        "author": user ? `${user.fName} ${user.lName}` : "Vilfredo Pareto",
+        "authorId": "8020",
+        "version": "1.0",
+        "missions": [
+          {
+            "_createdAt": "2021-02-01T00:14:21Z",
+            "_id": "2ba02c2c-3073-4fad-96d7-6d5fb9771709",
+            "_rev": "zU4HXxl43R2uTRsAhG6eAP",
+            "_type": "achievement",
+            "_updatedAt": "2022-08-21T16:43:39Z",
+            "summary": "Wake up at the same time each day, and check-in within 15 minutes.",
+            "title": "6am Club",
+            "type": "morning",
+            "xp": 100
+          },
+          {
+            "_createdAt": "2021-08-08T18:32:47Z",
+            "_id": "824b3644-cd9e-4897-a978-c22fb424c91d",
+            "_rev": "BTNQUBmTfX76gSzz4d56H6",
+            "_type": "achievement",
+            "_updatedAt": "2021-08-08T18:32:47Z",
+            "summary": "Drinking alcohol, especially alone, cripples performance and cognitive function - especially on a school night.",
+            "title": "No Alcohol",
+            "type": "fitness",
+            "xp": 100
+          },
+          {
+            "_createdAt": "2021-02-01T00:16:21Z",
+            "_id": "21862220-3bd6-4a95-ad03-c5a919049839",
+            "_rev": "iGUy6kFRUd9Q6s0z65x0zV",
+            "_type": "achievement",
+            "_updatedAt": "2021-08-17T21:03:46Z",
+            "summary": "Clock in, and clock out. There is no substitute for putting in the work, whether it's at your 9-5, you art, or your craft.",
+            "title": "3 Hours of Deep Work",
+            "type": "productivity",
+            "xp": 100
+          },
+          {
+            "_createdAt": "2021-02-01T00:21:04Z",
+            "_id": "61d7be0c-3c6b-4c82-9062-9c1dce3636b3",
+            "_rev": "iGUy6kFRUd9Q6s0z65x0Pr",
+            "_type": "achievement",
+            "_updatedAt": "2021-08-17T21:03:12Z",
+            "summary": "Accomplish your primary daily objective. Each day, there is something that is truly important. Have you finished that thing?",
+            "title": "Eat the Frog",
+            "type": "productivity",
+            "xp": 100
+          },
+          {
+            "_createdAt": "2021-02-01T00:38:21Z",
+            "_id": "37ba114e-67c0-48dd-aa8e-1add923d9099",
+            "_rev": "zU4HXxl43R2uTRsAhG6dDZ",
+            "_type": "achievement",
+            "_updatedAt": "2022-08-21T16:42:22Z",
+            "summary": "Water is life. Hydration is key to high performance.",
+            "title": "Drink 1 Liter of Water",
+            "type": "fitness",
+            "xp": 100
+          },
+          {
+            "_createdAt": "2021-02-01T00:17:23Z",
+            "_id": "3aa67ddc-d915-4517-b6c9-8f5c4aade79a",
+            "_rev": "7MVN483ot3n2svmGAYvB2n",
+            "_type": "achievement",
+            "_updatedAt": "2021-08-17T21:03:38Z",
+            "summary": "Whether it's playing a musical instrument, reading, writing or anything in between - do something special, creative and relaxing at night.",
+            "title": "Evening Creativity",
+            "type": "evening",
+            "xp": 100
+          }
+        ],
+        "planning": [],
+        "league": "Pareto Athletic Association (PAA)",
+        "createdAt": "2023-02-01T23:16:56.039Z",
+        "__v": 0
+      }
+}

--- a/src/utils/queries/createSprintTemplateQueries.ts
+++ b/src/utils/queries/createSprintTemplateQueries.ts
@@ -1,0 +1,41 @@
+import sanity from "../../libs/sanity";
+import { RestAPI } from "@aws-amplify/api-rest";
+import { I18n } from "@aws-amplify/core";
+
+/**
+ * Getting our potential sprint items from Sanity. Will likely need to replace later.
+ */
+export async function getSprintTemplateOptionsFromSanity() {
+    const query = `*[_type == 'achievement' && !(_id in path("drafts.**"))]`;
+  const links = await sanity.fetch(query);
+  console.log(links)
+    let initialData = {
+      Options: {
+        name: `${I18n.get("options")}`,
+        items: links,
+      },
+      Morning: {
+        name: `${I18n.get("morning")}`,
+        items: [],
+      },
+      Workday: {
+        name: `${I18n.get("workday")}`,
+        items: [],
+      },
+      Evening: {
+        name: `${I18n.get("evening")}`,
+        items: [],
+      },
+    };
+    console.log(initialData)
+    return initialData;
+  }
+
+  // pulls the /templates api and sets the existing templates
+export async function getSprintTemplates() {
+    return await RestAPI.get("pareto", "/templates", {});
+  }
+
+export async function setSprintTemplate(body: object) {
+    return await RestAPI.post("pareto", "/templates", { body });
+  }

--- a/src/utils/queries/initialFetchQueries.ts
+++ b/src/utils/queries/initialFetchQueries.ts
@@ -1,16 +1,16 @@
 import { RestAPI } from "@aws-amplify/api-rest";
 import sortby from "lodash.sortby";
-import sanity from "../libs/sanity";
+import sanity from "../../libs/sanity";
 
 interface ExperienceResult {
   success: boolean;
-  sanityTraining?: any;
-  sanityProduct?: any;
-  sanityInterview?: any;
-  training?: any;
-  product?: any;
-  interviewing?: any;
-  experiences?: any;
+  sanityTraining?: Object | null;
+  sanityProduct?: Object | null;
+  sanityInterview?: Object | null;
+  training?: Object | null;
+  product?: Object | null;
+  interviewing?: Object | null;
+  experiences?: Object | null;
 }
 
 export const fetchUser = async (username: string) => {
@@ -66,7 +66,7 @@ export const fetchStarterKitSanity = async () => {
   return result;
 };
 
-export const fetchStarterKitExperience = async (id: any) => {
+export const fetchStarterKitExperience = async (id: number | string) => {
   const result: ExperienceResult = {
     success: false,
     training: null,
@@ -80,7 +80,7 @@ export const fetchStarterKitExperience = async (id: any) => {
     let apprenticeship;
     let interviewing;
 
-    await experiences.forEach((exp: any) => {
+    await experiences.forEach((exp: Record<string, string>) => {
       if (exp.type === "Product") {
         product = exp;
       } else if (exp.type === "Apprenticeship") {

--- a/src/utils/queries/initialFetchQueries.ts
+++ b/src/utils/queries/initialFetchQueries.ts
@@ -4,13 +4,13 @@ import sanity from "../../libs/sanity";
 
 interface ExperienceResult {
   success: boolean;
-  sanityTraining?: Object | null;
-  sanityProduct?: Object | null;
-  sanityInterview?: Object | null;
-  training?: Object | null;
-  product?: Object | null;
-  interviewing?: Object | null;
-  experiences?: Object | null;
+  sanityTraining?: object | null;
+  sanityProduct?: object | null;
+  sanityInterview?: object | null;
+  training?: object | null;
+  product?: object | null;
+  interviewing?: object | null;
+  experiences?: object | null;
 }
 
 export const fetchUser = async (username: string) => {


### PR DESCRIPTION
## Description
Now that we've got the GitHub actions CI/CD is mostly functioning again (seems like there might still be some issues with the vercel deployment), I'd like to do some work to flesh out the unit & integration tests so that they can actually automatically catch breaking changes in the code. Hopefully with a few example PRs, we can also get new contributors participating as well!

This is the first in a series of PRs to flesh out unit tests related to the arena components (see `arena` folder of repository file structure). Going to leave it open for a bit for review/comments but I don't think this should be too controversial, so will probably merge myself in a few days if no feedback.

* Refactors component to enable external dependencies to more easily be mocked
* Adds some very basic unit tests just verifying that the initial state of the component is as expected
* Additional tests in the future will focus on form validation behavior, column drag-drop behavior, and edge cases (large amounts of data, failed API calls, etc.)

## Relates to
No specific issue, general housekeeping/developer experience improvement

## Reviewers
- @mikhael28 
- @jeremydthomas 

## Screenshots / other info

<img width="613" alt="Screen Shot 2023-02-01 at 6 43 11 PM" src="https://user-images.githubusercontent.com/84106309/216218261-a248c2f3-f0d8-45e3-8b30-07278cb770c0.png">
